### PR TITLE
Sriram: added symbian to platform.js for 'phonegap remote build symbian command to work'

### DIFF
--- a/lib/phonegap/util/platform.js
+++ b/lib/phonegap/util/platform.js
@@ -62,5 +62,10 @@ module.exports.map = {
         local: 'wp8',
         remote: null,
         human: 'Windows Phone 8'
+    },
+    symbian: {
+	    local: null,
+	    remote: 'symbian',
+	    human: 'Symbian'
     }
 };

--- a/spec/phonegap/util/platform.spec.js
+++ b/spec/phonegap/util/platform.spec.js
@@ -75,6 +75,20 @@ describe('platform', function() {
                     expect(platforms[0].local).toEqual('android');
                 });
             });
+
+            describe('symbian', function() {
+                beforeEach(function() {
+                    platforms = ['symbian'];
+                });
+
+                it('should support remote', function() {
+                    platforms = platform.names(platforms);
+                    expect(platforms.length).toEqual(1);
+                    expect(platforms[0].local).toBe(null);
+                    expect(platforms[0].remote).toBe('symbian');
+                    expect(platforms[0].human).toBe('Symbian');
+                });
+            });
         });
     });
 });


### PR DESCRIPTION
Added symbian entry to platform.js & updated corresponding spec file for the values added

Issue

Generating for symbian remote, breaks though it is supported. Checked the code and found that 'module.exports.map' in platform.js does not have an entry for symbian.

```
$ phonegap remote build symbian
~/.nvm/v0.10.12/lib/node_modules/phonegap/lib/phonegap/remote.build.js:71
    platforms: [ platform.remote ]
                         ^
TypeError: Cannot read property 'remote' of undefined
     at RemoteBuildCommand.execute (~/.nvm/v0.10.12/lib/node_modules/phonegap/lib/phonegap/remote.build.js:71:30)
     at RemoteBuildCommand.run (~/.nvm/v0.10.12/lib/node_modules/phonegap/lib/phonegap/remote.build.js:54:10)
     at Object.build (~/.nvm/v0.10.12/lib/node_modules/phonegap/lib/phonegap/util/command.js:28:25)
     at CLI.module.exports (~/.nvm/v0.10.12/lib/node_modules/phonegap/lib/cli/remote.build.js:39:21)
     at CLI.module.exports [as argv] (~/.nvm/v0.10.12/lib/node_modules/phonegap/lib/cli/argv.js:66:17)
     at Object.<anonymous> (~/.nvm/v0.10.12/lib/node_modules/phonegap/bin/phonegap.js:24:21)
     at Module._compile (module.js:456:26)
     at Object.Module._extensions..js (module.js:474:10)
     at Module.load (module.js:356:32)
     at Function.Module._load (module.js:312:12)
```
