### PR TITLE
Adding plugins should support --variables for plugins that require them

### DIFF
--- a/lib/cli/local.plugin.add.js
+++ b/lib/cli/local.plugin.add.js
@@ -26,7 +26,14 @@ module.exports = function(argv, callback) {
     }
 
     // plugin data
-    var data = { path: [argv._[3]] };
+    var data = {
+      path: [argv._[3]],
+      options: []
+    };
+
+    for(var v = 0; v < argv.variable.length; v++) {
+      data.options.push('--variable ' + argv.variable[v]);
+    }
 
     // add plugin
     phonegap.local.plugin.add(data, function(e, data) {


### PR DESCRIPTION
Currently the phonegap cli has no support for variables when adding plugins.

http://docs.phonegap.com/en/3.1.0/plugin_ref_spec.md.html#Plugin%20Specification

After a quick chat  in the phonegap IRC room a while back I was told that plugman shouldn't be required. I have ran into the problem where I want to be able to setup the Facebook plugin and have the ID and App name a required parameter. It would be nice to be able to support this from the phonegap cli.

I would imagine it working like the plugman version where it supports `--variable VAR=VALUE`

Referencing an issue as a reminder on another project here https://github.com/logankoester/grunt-phonegap/pull/6
