### PR TITLE
config command to modify config.xml preferences via command line

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 # Node
 /node_modules/
 npm-debug.log
+/nbproject/private/

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@
 
     Options:
 
-      -V, --verbose        allow verbose output
+      -d, --verbose        allow verbose output
       -v, --version        output version number
       -h, --help           output usage information
 
@@ -51,12 +51,10 @@
       keyword            | local environment | remote environment
       -------------------|-------------------|-------------------
       android            | ✔                 | ✔
-      blackberry         | ✔ (BlackBerry 10) | ✔ (BlackBerry 6)
+      blackberry10       | ✔                 | ✖
       ios                | ✔                 | ✔
-      symbian            | ✖                 | ✔
-      webos              | ✖                 | ✔
-      wp7                | ✔                 | ✔
-      wp8                | ✔                 | ✖
+      wp8                | ✔                 | ✔
+
 
     Examples:
 

--- a/bin/phonegap.js
+++ b/bin/phonegap.js
@@ -15,6 +15,8 @@ var CLI = require('../lib/cli'),
                               .boolean('version')
                               .boolean('h')
                               .boolean('help')
+                              .boolean('autoreload')
+                              .default('autoreload', true)
                               .argv;
 
 /*!

--- a/doc/cli/help.config.txt
+++ b/doc/cli/help.config.txt
@@ -1,0 +1,17 @@
+Usage: $0 config <path> [options]
+
+Description:
+
+  Modifies the config.xml file with the provided preferences and access settings.
+  Without parameters it just lists the current preferences and access.
+
+Options:
+
+  --preference <key>=<value>, -p <key>=<value>	Adds or override an existing preference called key with value
+  --access <url-pattern>, -a <url-pattern>		Adds a new access level.
+
+Examples:
+
+  $ $0 config /path/to/my-app
+  $ $0 config /path/to/my-app --preference orientation=landscape
+  $ $0 config /path/to/my-app -p orientation=landscape --access "http://myhost.com/*"

--- a/doc/cli/help.local.plugin.add.txt
+++ b/doc/cli/help.local.plugin.add.txt
@@ -1,3 +1,4 @@
+Usage: $0 plugin add <path>
 Usage: $0 local plugin add <path>
 
 Description:

--- a/doc/cli/help.local.plugin.list.txt
+++ b/doc/cli/help.local.plugin.list.txt
@@ -1,3 +1,4 @@
+Usage: $0 plugin list
 Usage: $0 local plugin list
 
 Description:

--- a/doc/cli/help.local.plugin.remove.txt
+++ b/doc/cli/help.local.plugin.remove.txt
@@ -1,3 +1,4 @@
+Usage: $0 plugin remove <id>
 Usage: $0 local plugin remove <id>
 
 Description:

--- a/doc/cli/help.local.plugin.txt
+++ b/doc/cli/help.local.plugin.txt
@@ -1,3 +1,4 @@
+Usage: $0 plugin <command>
 Usage: $0 local plugin <command>
 
 Description:
@@ -13,6 +14,7 @@ Commands:
 Examples:
 
   $ $0 local plugin add /local/path/to/plugin/
-  $ $0 local plugin add http://example.com/path/to/plugin.git
-  $ $0 local plugin remove org.apache.cordova.core.geolocation
-  $ $0 local plugin list
+  $ $0 plugin add /local/path/to/plugin/
+  $ $0 plugin add http://example.com/path/to/plugin.git
+  $ $0 plugin remove org.apache.cordova.core.geolocation
+  $ $0 plugin list

--- a/doc/cli/help.serve.txt
+++ b/doc/cli/help.serve.txt
@@ -1,4 +1,4 @@
-Usage: $0 app [options]
+Usage: $0 serve [options]
 
 Description:
 
@@ -10,8 +10,16 @@ Description:
 Options:
 
   --port, -p <n>       port for web server (default: 3000)
+  --autoreload         enable app refresh on file changes (default: true)
+  --no-autoreload      disable app refresh on file changes
+
+Alias:
+
+  $0 app
 
 Examples:
 
+  $ $0 serve
+  $ $0 serve --port 1337
+  $ $0 serve --no-autoreload
   $ $0 app
-  $ $0 app --port 1337

--- a/doc/cli/help.txt
+++ b/doc/cli/help.txt
@@ -5,7 +5,7 @@ Description:
   PhoneGap command-line tool.
 
 Commands:
-
+  config <path>        changes the config.xml parameters 
   create <path>        create a phonegap project
   build <platform>     build a specific platform
   install <platform>   install a specific platform
@@ -13,12 +13,13 @@ Commands:
   local [command]      development on local system
   remote [command]     development in cloud with phonegap/build
   platform [command]   update a platform version
+  plugin [command]     add, remove, and list plugins
   help [command]       output usage information
   version              output version number
 
 Options:
 
-  -V, --verbose        allow verbose output
+  -d, --verbose        allow verbose output
   -v, --version        output version number
   -h, --help           output usage information
 
@@ -27,12 +28,9 @@ Platforms:
   keyword            | local environment   | remote environment
   -------------------|---------------------|-------------------
   android            | Yes                 | Yes
-  blackberry         | Yes (BlackBerry 10) | Yes (BlackBerry 6)
   ios                | Yes                 | Yes
-  symbian            | No                  | Yes
-  webos              | No                  | Yes
-  wp7                | Yes                 | Yes
-  wp8                | Yes                 | Coming Soon
+  wp8                | Yes                 | Yes
+  Blackberry 10      | Yes                 | No 
 
 Examples:
 

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -15,6 +15,7 @@ function CLI() {
     this.local.cli = this;
     this.local.plugin.cli = this;
     this.platform.cli = this;
+    this.plugin.cli = this;
     this.remote.cli = this;
 }
 
@@ -22,9 +23,9 @@ function CLI() {
  * Command line commands.
  */
 
-CLI.prototype.app = require('./cli/app');
 CLI.prototype.argv = require('./cli/argv');
 CLI.prototype.build = require('./cli/build');
+CLI.prototype.config = require('./cli/config');
 CLI.prototype.create = require('./cli/create');
 CLI.prototype.help = require('./cli/help');
 CLI.prototype.install = require('./cli/install');
@@ -38,6 +39,10 @@ CLI.prototype.local.plugin.remove = require('./cli/local.plugin.remove');
 CLI.prototype.local.run = require('./cli/local.run');
 CLI.prototype.platform = require('./cli/platform');
 CLI.prototype.platform.update = require('./cli/platform.update');
+CLI.prototype.plugin = require('./cli/plugin');
+CLI.prototype.plugin.add = require('./cli/plugin.add');
+CLI.prototype.plugin.remove = require('./cli/plugin.remove');
+CLI.prototype.plugin.list = require('./cli/plugin.list');
 CLI.prototype.remote = require('./cli/remote');
 CLI.prototype.remote.build = require('./cli/remote.build');
 CLI.prototype.remote.install = require('./cli/remote.install');
@@ -45,6 +50,8 @@ CLI.prototype.remote.login = require('./cli/remote.login');
 CLI.prototype.remote.logout = require('./cli/remote.logout');
 CLI.prototype.remote.run = require('./cli/remote.run');
 CLI.prototype.run = require('./cli/run');
+CLI.prototype.serve = require('./cli/serve');
+CLI.prototype.app = CLI.prototype.serve;
 CLI.prototype.unknown = require('./cli/unknown');
 CLI.prototype.version = require('./cli/version');
 

--- a/lib/cli/argv.js
+++ b/lib/cli/argv.js
@@ -26,7 +26,7 @@ module.exports = function(argv, callback) {
     }
 
     // --verbose
-    if (argv.verbose || argv.V) {
+    if (argv.verbose || argv.d) {
         phonegap.mode({ verbose: true });
     }
 

--- a/lib/cli/config.js
+++ b/lib/cli/config.js
@@ -1,0 +1,61 @@
+/*!
+ * Module dependencies.
+ */
+
+var phonegap = require('../main'),
+    fs = require('fs');
+
+/**
+ * $ phonegap config [key=value [key=value]]
+ *
+ * Config interface to interact with the config.xml file.
+ *
+ * Options:
+ *
+ *   - `argv` {Object} is an optimist object.
+ *   - `callback` {Function} is a completion callback.
+ *     - `e` {Error} is null unless there was an error.
+ */
+
+module.exports = function(argv, callback) {
+    // display help on $ phonegap create
+    if (argv._.length <= 0) {
+        argv._.unshift('help');
+        this.argv(argv, callback);
+        return;
+    }
+	
+	argv.access = argv.access || [];
+	argv.a = argv.a || [];
+	if(!(argv.access instanceof Array)) argv.access = [argv.access];
+	if(!(argv.a instanceof Array)) argv.a = [argv.a];
+	argv.access = argv.access.concat(argv.a);
+	
+	argv.preference = argv.preference || [];
+	argv.p = argv.p || [];
+	if(!(argv.preference instanceof Array)) argv.preference = [argv.preference];
+	if(!(argv.p instanceof Array)) argv.p = [argv.p];
+	argv.preference = argv.preference.concat(argv.p);
+	
+	// information that might be customizable
+    var data = {
+		preference: [],
+		access: []
+    };
+	
+	// read the access flags from the args
+	argv.access.forEach(function(access){
+		data.access.push(access);
+	});
+	
+	// read the preference flags from the args
+	argv.preference.forEach(function(preference){
+		var split = preference.split('=');
+		data.preference.push({name:split[0],value:split[1]});
+	});
+	
+	// config the project
+    phonegap.config(data, function(e) {
+        callback(e);
+    });
+};

--- a/lib/cli/help.js
+++ b/lib/cli/help.js
@@ -28,10 +28,18 @@ module.exports = function(argv, callback) {
     filepath.push('txt');
     filepath = filepath.join('.');
 
+    // alias for the serve command
+    filepath = filepath.replace('help.app.txt', 'help.serve.txt');
+    filepath = filepath.replace('help.plugin', 'help.local.plugin');
+
     // full path
     filepath = path.join(basepath, filepath);
 
     // get help info and replace $0 with process name
+    if (!fs.existsSync(filepath)) {
+        this.cli.unknown(argv, callback);
+        return;
+    }
     data = fs.readFileSync(filepath, 'utf8');
     data = data.trim().replace(/\$0/g, argv.$0);
 

--- a/lib/cli/plugin.add.js
+++ b/lib/cli/plugin.add.js
@@ -1,0 +1,35 @@
+/*!
+ * Module dependencies.
+ */
+
+var phonegap = require('../main');
+
+/**
+ * $ phonegap plugin add <path>
+ *
+ * Add a plugin to the application locally.
+ *
+ * Options:
+ *
+ *   - `argv` {Object} is an optimist object.
+ *   - `callback` {Function} is a completion callback.
+ *     - `e` {Error} is null unless there was an error.
+ *     - `data` {Object} describes the built app.
+ */
+
+module.exports = function(argv, callback) {
+    // display help when missing required parameter <platform>
+    if (argv._.length <= 2) {
+        argv._.unshift('help');
+        this.cli.argv(argv, callback);
+        return;
+    }
+
+    // plugin data
+    var data = { path: [argv._[2]] };
+
+    // add plugin
+    phonegap.plugin.add(data, function(e, data) {
+        callback(e, data);
+    });
+};

--- a/lib/cli/plugin.js
+++ b/lib/cli/plugin.js
@@ -1,0 +1,29 @@
+/*!
+ * Module dependencies.
+ */
+
+/**
+ * $ phonegap plugin [command]
+ *
+ * Groups all of the plugin commands under the... plugin... command.
+ *
+ * Options:
+ *
+ *   - `argv` {Object} is an optimist object.
+ *   - `callback` {Function} is a completion callback.
+ *     - `e` {Error} is null unless there was an error.
+ */
+
+module.exports = function(argv, callback) {
+    var self = this;
+
+    // display help when given no command
+    if (argv._.length <= 1) {
+        argv._.unshift('help');
+        self.argv(argv, callback);
+        return;
+    }
+
+    // command is unknown
+    self.cli.unknown(argv, callback);
+};

--- a/lib/cli/plugin.list.js
+++ b/lib/cli/plugin.list.js
@@ -1,0 +1,25 @@
+/*!
+ * Module dependencies.
+ */
+
+var phonegap = require('../main');
+
+/**
+ * $ phonegap plugin list
+ *
+ * List installed plugins.
+ *
+ * Options:
+ *
+ *   - `argv` {Object} is an optimist object.
+ *   - `callback` {Function} is a completion callback.
+ *     - `e` {Error} is null unless there was an error.
+ *     - `data` {Object} describes the built app.
+ */
+
+module.exports = function(argv, callback) {
+    // list installed plugins
+    phonegap.plugin.list({}, function(e, data) {
+        callback(e, data);
+    });
+};

--- a/lib/cli/plugin.remove.js
+++ b/lib/cli/plugin.remove.js
@@ -1,0 +1,35 @@
+/*!
+ * Module dependencies.
+ */
+
+var phonegap = require('../main');
+
+/**
+ * $ phonegap plugin remove <id>
+ *
+ * Remove a plugin from the application locally.
+ *
+ * Options:
+ *
+ *   - `argv` {Object} is an optimist object.
+ *   - `callback` {Function} is a completion callback.
+ *     - `e` {Error} is null unless there was an error.
+ *     - `data` {Object} describes the built app.
+ */
+
+module.exports = function(argv, callback) {
+    // display help when missing required parameter <platform>
+    if (argv._.length <= 2) {
+        argv._.unshift('help');
+        this.cli.argv(argv, callback);
+        return;
+    }
+
+    // plugin data
+    var data = { id: [argv._[2]] };
+
+    // remove plugin
+    phonegap.plugin.remove(data, function(e, data) {
+        callback(e, data);
+    });
+};

--- a/lib/cli/serve.js
+++ b/lib/cli/serve.js
@@ -6,7 +6,7 @@ var phonegap = require('../main'),
     console = require('./util/console');
 
 /**
- * $ phonegap app [options]
+ * $ phonegap serve [options]
  *
  * Serves the app on a local web server.
  *
@@ -20,11 +20,11 @@ var phonegap = require('../main'),
 module.exports = function(argv, callback) {
     // options
     var data = {
-        port: argv.port || argv.p
+        port: argv.port || argv.p,
+        autoreload: argv.autoreload
     };
 
-    // run app command
-    var app = phonegap.app(data, function(e, server) {
+    phonegap.serve(data, function(e, server) {
         if (!e) {
             console.log('');
             console.log('ctrl-c to stop the server');

--- a/lib/phonegap.js
+++ b/lib/phonegap.js
@@ -27,8 +27,8 @@ function PhoneGap() {
     initialize.call(this);
 
     // initialize each command and inject the `phonegap` dependency.
-    this.app = require('./phonegap/app').create(this);
     this.build = require('./phonegap/build').create(this);
+    this.config = require('./phonegap/config').create(this);
     this.create = require('./phonegap/create').create(this);
     this.install = require('./phonegap/install').create(this);
     this.local.build = require('./phonegap/local.build').create(this);
@@ -36,6 +36,7 @@ function PhoneGap() {
     this.local.plugin.add = require('./phonegap/local.plugin.add').create(this);
     this.local.plugin.list = require('./phonegap/local.plugin.list').create(this);
     this.local.plugin.remove = require('./phonegap/local.plugin.remove').create(this);
+    this.plugin = this.local.plugin;
     this.local.run = require('./phonegap/local.run').create(this);
     this.mode = require('./phonegap/mode').create(this);
     this.platform.update = require('./phonegap/platform.update').create(this);
@@ -45,6 +46,8 @@ function PhoneGap() {
     this.remote.logout = require('./phonegap/remote.logout').create(this);
     this.remote.run = require('./phonegap/remote.run').create(this);
     this.run = require('./phonegap/run').create(this);
+    this.serve = require('./phonegap/serve').create(this);
+    this.app = this.serve;
     this.version = require('./phonegap/version').create(this);
 
     // set normal mode (not verbose and not quiet)
@@ -69,8 +72,10 @@ PhoneGap.prototype.remote = {};
 function initialize() {
     var self = this;
 
-    // error events must always have a listener.
-    self.on('error', function(e) {});
+    // set error event listener to log to stderr
+    self.on('error', function(e) {
+        console.error(e);
+    });
 
     // reset all phonegapbuild event listeners
     phonegapbuild.removeAllListeners();

--- a/lib/phonegap/build.js
+++ b/lib/phonegap/build.js
@@ -79,6 +79,8 @@ BuildCommand.prototype.execute = function(options, callback) {
         self.phonegap[env].build(options, callback);
     }, function (e) {
         var env = 'remote';
+        // emit a non-exiting message to stderr, incase user wants to react to local build failure
+        self.phonegap.emit('error',e);
         self.phonegap.emit('log', 'using the', env, 'environment');
         self.phonegap[env].build(options, callback);
     });

--- a/lib/phonegap/config.js
+++ b/lib/phonegap/config.js
@@ -1,0 +1,140 @@
+/*!
+ * Module dependencies.
+ */
+
+var Command = require('./util/command'),
+    cordova = require('cordova'),
+    shell = require('shelljs'),
+    path = require('path'),
+    util = require('util'),
+	et = require('elementtree'),
+	fs = require('fs');
+
+/*!
+ * Command setup.
+ */
+
+module.exports = {
+    create: function(phonegap) {
+        return new ConfigCommand(phonegap);
+    }
+};
+
+function ConfigCommand(phonegap) {
+    return Command.apply(this, arguments);
+}
+
+util.inherits(ConfigCommand, Command);
+
+/**
+ * Config an existing app
+ *
+ * Config an app changing existing preferences or adding new preferences or access.
+ *
+ * Options:
+ *
+ *   - `options` {Object} is data required to create an app
+ *     - `path` {String} is a directory path for the app.
+ *     - `preference` {Array} is the application name (default: 'Hello World')
+ *     - `access` {Array} is the package name (default: 'com.phonegap.hello-world')
+ *   - [`callback`] {Function} is triggered after creating the app.
+ *     - `e` {Error} is null unless there is an error.
+ *
+ * Returns:
+ *
+ *   {PhoneGap} for chaining.
+ */
+
+ConfigCommand.prototype.run = function(options, callback) {
+    // require options
+    if (!options) throw new Error('requires option parameter');
+	if (!options.preference || !(options.preference instanceof Array)) throw new Error('requires option.preference parameter as an Array');
+	if (!options.access || !(options.access instanceof Array)) throw new Error('requires option.access parameter as an Array');
+
+    // optional callback
+    callback = callback || function() {};
+
+    // validate options
+	options.path = path.resolve("www","config.xml");
+	
+    // config app
+    this.execute(options, callback);
+
+    return this.phonegap;
+};
+
+/*!
+ * Execute.
+ */
+
+ConfigCommand.prototype.execute = function(options, callback) {
+    // customize default app
+    var configs = this.parseElementtreeSync(options.path);
+	
+	// if there is no preferences and no access to add modify, just iterate and list current ones.
+	if(options.preference.length === 0 && options.access.length === 0){
+		this.printCurrentPreferences(configs);
+	}else{
+		configs = this.updatePreferences(options, configs);
+		configs = this.updateAccesses(options, configs);
+		
+		//write the file back
+		fs.writeFileSync(options.path, configs.write({indent: 4}), 'utf-8');
+	}
+	
+	callback(null);
+};
+
+ConfigCommand.prototype.printCurrentPreferences = function (doc){
+	//print out the current values only
+	var output = "Preferences\n";
+	doc.findall('preference').forEach(function(e){
+		output += e.attrib.name+': '+e.attrib.value + "\n";
+	});
+	output += "\nAccess\n";
+	doc.findall('access').forEach(function(e){
+		output += 'origin: '+e.attrib.origin + "\n";
+	});
+	console.log(output);
+};
+
+ConfigCommand.prototype.updatePreferences = function (options, doc){
+	//apply the new values to the dom object
+	options.preference.forEach(function(p){
+		//check if the preference exists already
+		var pref = doc.find('preference[@name="'+p.name+'"]');
+		if(pref){ 
+			//update the value
+			pref.attrib.value = p.value;
+		}else{ 
+			//add the new node
+			var el = new et.Element('preference');
+			el.attrib.name = p.name;
+			el.attrib.value = p.value;
+			doc.getroot().append(el);
+		}
+	});
+	
+	return doc;
+};
+
+ConfigCommand.prototype.updateAccesses = function(options, doc){
+	options.access.forEach(function(access){
+		var acc = doc.find('access[@origin="'+access+'"]');
+		if(!acc){ //don't include the same access again
+			var el = new et.Element('access');
+			el.attrib.origin = access;
+			doc.getroot().append(el);
+		}
+	});
+	
+	return doc;
+};
+
+ConfigCommand.prototype.parseElementtreeSync = function (filename) {
+	var contents = fs.readFileSync(filename, 'utf-8');
+	if(contents) {
+		contents = contents.replace(/^\uFEFF/, ''); //Windows is the BOM
+	}
+	return new et.ElementTree(et.XML(contents));
+};

--- a/lib/phonegap/create.js
+++ b/lib/phonegap/create.js
@@ -6,7 +6,8 @@ var Command = require('./util/command'),
     cordova = require('cordova'),
     shell = require('shelljs'),
     path = require('path'),
-    util = require('util');
+    util = require('util'),
+    fs = require('fs');
 
 /*!
  * Command setup.
@@ -53,14 +54,15 @@ CreateCommand.prototype.run = function(options, callback) {
     callback = callback || function() {};
 
     // validate options
-    options.path = path.resolve(options.path);
+    options.path = path.resolve(options.path.toString());
+
     options.name = options.name || 'HelloWorld';
     options.id = options.id || 'com.phonegap.helloworld';
 
     // create app
     this.execute(options, callback);
 
-    return this.phonegap;
+   return this.phonegap;
 };
 
 /*!
@@ -72,20 +74,11 @@ CreateCommand.prototype.execute = function(options, callback) {
         version = self.phonegap.version().phonegap,
         uri = 'https://github.com/phonegap/phonegap-app-hello-world/archive/' +
               version + '.tar.gz';
-
-    // customize default app
-    cordova.config(options.path, {
-        lib: {
-            www: {
-                id: 'phonegap',
-                version: version,
-                uri: uri
-            }
-        }
-    });
-
+    
     // create local project
     cordova.create(options.path, options.id, options.name, function(e) {
+        self.phonegap.emit('log','the options', options.path, options.id, options.name);
+
         if (e) {
             self.phonegap.emit('error', e);
             callback(e);

--- a/lib/phonegap/local.plugin.list.js
+++ b/lib/phonegap/local.plugin.list.js
@@ -62,19 +62,38 @@ LocalPluginListCommand.prototype.execute = function(options, callback) {
     // change to project directory and delegate errors
     if (!project.cd({ emitter: self.phonegap, callback: callback })) return;
 
-    // list plugins
-    cordova.plugin('list', [], function(e, plugins) {
-        if (e) {
-            self.phonegap.emit('error', e);
-            callback(e);
-            return;
-        }
+    // cordova returns the plugins through the 'results' event
+    // this is an awkward workflow, but we will make it work.
+    cordova.on('results', function listEventHandler(plugins) {
+        cordova.removeListener('results', listEventHandler);
+        self.listPlugins(plugins, callback);
+    });
 
-        // list plugins
+    // list plugins
+    cordova.plugin('list');
+};
+
+LocalPluginListCommand.prototype.listPlugins = function(plugins, callback) {
+    var self = this,
+        e = null;
+
+    // error is not supported by cordova, but this is for the future
+    if (plugins instanceof Error) {
+        e = plugins;
+        plugins = [];
+        self.phonegap.emit('error', e);
+    }
+    // no plugins are displayed as a string instead of empty array
+    else if (typeof plugins === 'string') {
+        plugins = [];
+        self.phonegap.emit('log', 'no plugins installed');
+    }
+    // list plugins
+    else {
         for(var key in plugins) {
             self.phonegap.emit('log', plugins[key]);
         }
+    }
 
-        callback(null, plugins);
-    });
+    callback(e, plugins);
 };

--- a/lib/phonegap/serve.js
+++ b/lib/phonegap/serve.js
@@ -4,7 +4,7 @@
 
 var Command = require('./util/command'),
     project = require('./util/project'),
-    Static = require('node-static'),
+    server = require('connect-phonegap'),
     util = require('util');
 
 /*!
@@ -34,6 +34,7 @@ util.inherits(AppCommand, Command);
  *
  *   - `options` {Object}
  *     - `[port]` {Number} is the server port (default: 3000).
+ *     - `[autoreload]` {Boolean} refreshes app on file system changes (default: true)
  *   - `[callback]` {Function} is triggered when server starts.
  *     - `e` {Error} is null unless there is an error.
  *
@@ -48,6 +49,7 @@ AppCommand.prototype.run = function(options, callback) {
 
     // optional parameters
     options.port = options.port || 3000;
+    options.autoreload = (typeof options.autoreload === 'boolean') ? options.autoreload : true;
     callback = callback || function() {};
 
     // start app
@@ -61,40 +63,22 @@ AppCommand.prototype.run = function(options, callback) {
  */
 
 AppCommand.prototype.execute = function(options, callback) {
-    var self = this,
-        file = new Static.Server('./www');
+    var self = this;
 
     // change to project directory and delegate errors
     if (!project.cd({ emitter: self.phonegap, callback: callback })) return;
 
-    // create the server
-    var server = require('http').createServer(function (request, response) {
-        // on a request
-        request.on('end', function () {
-            // server the static file
-            file.serve(request, response, function(e, response) {
-                if (e) response = e; // e.status = 404
-                self.phonegap.emit('log', response.status, request.url);
-            });
-        });
-    });
-
-    // bind error
-    server.on('error', function(e) {
+    server.listen(options)
+    .on('error', function(e) {
         self.phonegap.emit('error', e);
         callback(e);
+    })
+    .on('log', function(statusCode, url) {
+        self.phonegap.emit('log', statusCode, url);
+    })
+    .on('complete', function(data) {
+        callback(null, data);
     });
 
-    // bind complete
-    server.on('listening', function() {
-        self.phonegap.emit('log', 'listening on 127.0.0.1:' + options.port);
-        callback(null, {
-            address: '127.0.0.1',
-            port: options.port
-        });
-    });
-
-    // start the server
     self.phonegap.emit('log', 'starting app server...');
-    server.listen(options.port);
 };

--- a/lib/phonegap/util/platform.js
+++ b/lib/phonegap/util/platform.js
@@ -55,17 +55,17 @@ module.exports.map = {
     },
     wp7: {
         local: 'wp7',
-        remote: 'winphone',
+        remote: null,
         human: 'Windows Phone 7'
     },
     wp8: {
         local: 'wp8',
-        remote: null,
+        remote: 'winphone',
         human: 'Windows Phone 8'
     },
-    symbian: {
-	    local: null,
-	    remote: 'symbian',
-	    human: 'Symbian'
+    firefoxos: {
+        local: 'firefoxos',
+        remote: null,
+        human: 'Fire Fox OS'
     }
 };

--- a/lib/phonegap/util/project.js
+++ b/lib/phonegap/util/project.js
@@ -85,3 +85,23 @@ module.exports.isProject = function(projectPath) {
 module.exports.isHome = function(homePath) {
     return (homePath === HOME);
 };
+
+
+module.exports.clobberProjectConfig = function(configPath,clobbertargets) {
+    var fs = require('fs');
+     
+    fs.open(configPath,'r+', function(err,fd) {
+        if (err) {
+            return;
+        }
+        fs.readFile(configPath, function(err, data) {
+            if(err) {
+                return;
+            }
+            for (each in clobbertargets) {
+                data.replace(each, clobbertargets[each]);
+            }
+        });
+    });
+    return configPath;
+};

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "phonegap",
     "description": "PhoneGap command-line interface and node.js library.",
-    "version": "3.2.0-0.16.0",
+    "version": "3.4.0-0.19.16",
     "homepage": "http://github.com/phonegap/phonegap-cli",
     "repository": {
         "type": "git",
@@ -28,15 +28,16 @@
     },
     "dependencies": {
         "colors": "0.6.0-1",
-        "cordova": "3.2.0-0.2.0",
-        "node-static": "0.7.0",
+        "connect-phonegap": "0.9.0",
+        "cordova": "3.4.0-0.1.3",
         "optimist": "0.6.0",
         "phonegap-build": "0.8.4",
         "pluralize": "0.0.4",
         "prompt": "0.2.11",
         "qrcode-terminal": "0.9.4",
         "semver": "1.1.0",
-        "shelljs": "0.1.4"
+        "shelljs": "0.1.4",
+        "elementtree": "0.1.5"
     },
     "devDependencies": {
         "jasmine-node": "1.8.0",

--- a/spec/cli.spec.js
+++ b/spec/cli.spec.js
@@ -5,6 +5,7 @@ var shell = require('shelljs'),
 describe('$ phonegap [options] commands', function() {
     beforeEach(function() {
         spyOn(process.stdout, 'write');
+        spyOn(process.stderr, 'write');
     });
 
     it('should support no arguments', function() {

--- a/spec/cli/app.spec.js
+++ b/spec/cli/app.spec.js
@@ -16,6 +16,7 @@ describe('phonegap help app', function() {
         cli = new CLI();
         spyOn(phonegap, 'app');
         spyOn(process.stdout, 'write');
+        spyOn(process.stderr, 'write');
         stdout = process.stdout.write;
     });
 
@@ -29,28 +30,28 @@ describe('phonegap help app', function() {
     describe('$ phonegap help app', function() {
         it('should output usage info', function() {
             cli.argv({ _: ['help', 'app'] });
-            expect(stdout.mostRecentCall.args[0]).toMatch(/usage: [\S]+ app/i);
+            expect(stdout.mostRecentCall.args[0]).toMatch(/usage: [\S]+ serve/i);
         });
     });
 
     describe('$ phonegap app help', function() {
         it('should output usage info', function() {
             cli.argv({ _: ['app', 'help'] });
-            expect(stdout.mostRecentCall.args[0]).toMatch(/usage: [\S]+ app/i);
+            expect(stdout.mostRecentCall.args[0]).toMatch(/usage: [\S]+ serve/i);
         });
     });
 
     describe('$ phonegap app --help', function() {
         it('should output usage info', function() {
             cli.argv({ _: ['app'], help: true });
-            expect(stdout.mostRecentCall.args[0]).toMatch(/usage: [\S]+ app/i);
+            expect(stdout.mostRecentCall.args[0]).toMatch(/usage: [\S]+ serve/i);
         });
     });
 
     describe('$ phonegap app -h', function() {
         it('should output usage info', function() {
             cli.argv({ _: ['app'], h: true });
-            expect(stdout.mostRecentCall.args[0]).toMatch(/usage: [\S]+ app/i);
+            expect(stdout.mostRecentCall.args[0]).toMatch(/usage: [\S]+ serve/i);
         });
     });
 });
@@ -63,31 +64,15 @@ describe('phonegap app', function() {
     beforeEach(function() {
         cli = new CLI();
         spyOn(process.stdout, 'write');
-        spyOn(phonegap, 'app').andReturn({
+        spyOn(phonegap, 'serve').andReturn({
             on: function(){}
         });
     });
 
     describe('$ phonegap app', function() {
-        it('should connect to phonegap app', function() {
+        it('should use phonegap.serve', function() {
             cli.argv({ _: ['app'] });
-            expect(phonegap.app).toHaveBeenCalled();
-        });
-    });
-
-    describe('$ phonegap app --port 1337', function() {
-        it('should connect to phonegap app on port 1337', function() {
-            cli.argv({ _: ['app'], port: 1337 });
-            expect(phonegap.app).toHaveBeenCalled();
-            expect(phonegap.app.mostRecentCall.args[0]).toEqual({ port: 1337 });
-        });
-    });
-
-    describe('$ phonegap app -p 1337', function() {
-        it('should connect to phonegap app on port 1337', function() {
-            cli.argv({ _: ['app'], p: 1337 });
-            expect(phonegap.app).toHaveBeenCalled();
-            expect(phonegap.app.mostRecentCall.args[0]).toEqual({ port: 1337 });
+            expect(phonegap.serve).toHaveBeenCalled();
         });
     });
 });

--- a/spec/cli/build.spec.js
+++ b/spec/cli/build.spec.js
@@ -15,6 +15,7 @@ describe('phonegap help build', function() {
     beforeEach(function() {
         cli = new CLI();
         spyOn(process.stdout, 'write');
+        spyOn(process.stderr, 'write');
         stdout = process.stdout.write;
     });
 
@@ -70,6 +71,7 @@ describe('phonegap build <platform>', function() {
         cli = new CLI();
         spyOn(phonegap, 'build');
         spyOn(process.stdout, 'write');
+        spyOn(process.stderr, 'write');
         stdout = process.stdout.write;
     });
 

--- a/spec/cli/config.spec.js
+++ b/spec/cli/config.spec.js
@@ -1,0 +1,232 @@
+/*
+ * Module dependencies.
+ */
+
+var phonegap = require('../../lib/main'),
+    CLI = require('../../lib/cli'),
+    cli,
+    stdout;
+
+/*
+ * Specification: $ phonegap help config
+ */
+
+describe('phonegap help config', function() {
+	beforeEach(function() {
+        cli = new CLI();
+        spyOn(process.stdout, 'write');
+        stdout = process.stdout.write;
+	});
+	
+	    describe('$ phonegap help', function() {
+        it('should include the command', function() {
+            cli.argv({ _: ['help'] });
+            expect(stdout.mostRecentCall.args[0]).toMatch(/\r?\n\s+config.*\r?\n/i);
+        });
+    });
+
+    describe('$ phonegap config', function() {
+		var originalFs;
+		beforeEach(function(){
+			var fs = require('fs');
+			originalFs = fs.readFileSync;
+			fs.readFileSync = function(path, encoding){
+				return '<?xml version="1.0" encoding="utf-8"?>\\n\
+<widget id="com.spilgames.dev.hello4" version="1.0.0" xmlns="http://www.w3.org/ns/widgets" xmlns:gap="http://phonegap.com/ns/1.0">\\n\
+	<feature name="http://api.phonegap.com/1.0/device" />\\n\
+	<preference name="permissions" value="none" />\\n\
+	<icon src="icon.png" />\\n\
+	<icon gap:density="ldpi" gap:platform="android" src="res/icon/android/icon-36-ldpi.png" />\\n\
+	<gap:splash gap:density="ldpi" gap:platform="android" src="res/screen/android/screen-ldpi-portrait.png" />\\n\
+	<access origin="http://myhost2.com/*" />\\n\
+</widget>';
+			};
+		});
+		
+		afterEach(function(){
+			var fs = require('fs');
+			fs.readFileSync = originalFs;
+		});
+
+        it('should print the preferences of the project', function(){
+			cli.argv({ _: ['config'] });
+			expect(stdout.mostRecentCall.args[0]).toMatch(/Preferences/i);
+		});
+		it('should print the access of the project', function(){
+			cli.argv({ _: ['config'] });
+            expect(stdout.mostRecentCall.args[0]).toMatch(/Access/i);
+		});
+    });
+
+    describe('$ phonegap help config', function() {
+        it('should output usage info', function() {
+            cli.argv({ _: ['help', 'config'] });
+            expect(stdout.mostRecentCall.args[0]).toMatch(/usage: [\S]+ config/i);
+        });
+    });
+
+    describe('$ phonegap config help', function() {
+        it('should output usage info', function() {
+            cli.argv({ _: ['config', 'help'] });
+            expect(stdout.mostRecentCall.args[0]).toMatch(/usage: [\S]+ config/i);
+        });
+    });
+
+    describe('$ phonegap config --help', function() {
+        it('should output usage info', function() {
+            cli.argv({ _: ['config'], help: true });
+            expect(stdout.mostRecentCall.args[0]).toMatch(/usage: [\S]+ config/i);
+        });
+    });
+
+    describe('$ phonegap config -h', function() {
+        it('should output usage info', function() {
+            cli.argv({ _: ['config'], h: true });
+            expect(stdout.mostRecentCall.args[0]).toMatch(/usage: [\S]+ config/i);
+        });
+    });
+});
+
+/*
+ * Specification: $ phonegap config <path> [options]
+ */
+
+describe('phonegap config [options]', function() {
+    beforeEach(function() {
+        cli = new CLI();
+        spyOn(process.stdout, 'write');
+        spyOn(phonegap, 'config');
+    });
+
+    describe('$ phonegap config', function() {
+        it('should try to config the project', function() {
+            cli.argv({ _: ['config'] });
+            expect(phonegap.config).toHaveBeenCalledWith({
+                preference: [],
+                access: []
+            },
+            jasmine.any(Function));
+        });
+    });
+	
+    describe('$ phonegap config -p orientation=landscape', function() {
+        it('should try to config the project', function() {
+            cli.argv({ _: ['config'], p:'orientation=landscape'});
+            expect(phonegap.config).toHaveBeenCalledWith({
+                preference: [{ name:'orientation', value:'landscape'}],
+                access: []
+            },
+            jasmine.any(Function));
+        });
+    });
+	
+	describe('$ phonegap config --preference orientation=landscape', function() {
+        it('should try to config the project', function() {
+            cli.argv({ _: ['config'], preference:'orientation=landscape'});
+            expect(phonegap.config).toHaveBeenCalledWith({
+                preference: [{ name:'orientation', value:'landscape'}],
+                access: []
+            },
+            jasmine.any(Function));
+        });
+    });
+	
+	describe('$ phonegap config -p orientation=landscape -p fullscreen=false', function() {
+        it('should try to config the project', function() {
+            cli.argv({ _: ['config'], p:['orientation=landscape', 'fullscreen=false']});
+            expect(phonegap.config).toHaveBeenCalledWith({
+                preference: [{ name:'orientation', value:'landscape'}, { name:'fullscreen', value:'false'}],
+                access: []
+            },
+            jasmine.any(Function));
+        });
+    });
+	
+	describe('$ phonegap config --preference orientation=landscape --preference fullscreen=false', function() {
+        it('should try to config the project', function() {
+            cli.argv({ _: ['config'], preference:['orientation=landscape', 'fullscreen=false']});
+            expect(phonegap.config).toHaveBeenCalledWith({
+                preference: [{ name:'orientation', value:'landscape'}, { name:'fullscreen', value:'false'}],
+                access: []
+            },
+            jasmine.any(Function));
+        });
+    });
+	
+	describe('$ phonegap config --preference orientation=landscape -p fullscreen=false', function() {
+        it('should try to config the project', function() {
+            cli.argv({ _: ['config'], preference:'orientation=landscape',p:'fullscreen=false'});
+            expect(phonegap.config).toHaveBeenCalledWith({
+				preference: [{ name:'orientation', value:'landscape'}, { name:'fullscreen', value:'false'}],
+                access: []
+            },
+            jasmine.any(Function));
+        });
+    });
+	
+	describe('$ phonegap config -a "http://myhost.com/*"', function() {
+        it('should try to config the project', function() {
+            cli.argv({ _: ['config'], a:'http://myhost.com/*'});
+            expect(phonegap.config).toHaveBeenCalledWith({
+                preference: [],
+                access: ['http://myhost.com/*']
+            },
+            jasmine.any(Function));
+        });
+    });
+	
+	describe('$ phonegap config --access "http://myhost.com/*"', function() {
+        it('should try to config the project', function() {
+            cli.argv({ _: ['config'], access:'http://myhost.com/*'});
+            expect(phonegap.config).toHaveBeenCalledWith({
+                preference: [],
+                access: ['http://myhost.com/*']
+            },
+            jasmine.any(Function));
+        });
+    });
+	
+	describe('$ phonegap config -a "http://myhost.com/*" -a "http://example.com/*"', function() {
+        it('should try to config the project', function() {
+            cli.argv({ _: ['config'], a:['http://myhost.com/*', 'http://example.com/*']});
+            expect(phonegap.config).toHaveBeenCalledWith({
+                preference: [],
+                access: ['http://myhost.com/*', 'http://example.com/*']
+            },
+            jasmine.any(Function));
+        });
+    });
+	
+	describe('$ phonegap config --access orientation=landscape --access fullscreen=false', function() {
+        it('should try to config the project', function() {
+            cli.argv({ _: ['config'], access:['http://myhost.com/*', 'http://example.com/*']});
+            expect(phonegap.config).toHaveBeenCalledWith({
+                preference: [],
+                access: ['http://myhost.com/*', 'http://example.com/*']
+            },
+            jasmine.any(Function));
+        });
+    });
+	
+	describe('$ phonegap config --access "http://myhost.com/*" -a "http://example.com/*"', function() {
+        it('should try to config the project', function() {
+            cli.argv({ _: ['config'], access:'http://myhost.com/*',a:'http://example.com/*'});
+            expect(phonegap.config).toHaveBeenCalledWith({
+                preference: [],
+                access: ['http://myhost.com/*', 'http://example.com/*']
+            },
+            jasmine.any(Function));
+        });
+    });
+	
+	describe('$ phonegap config -p orientation=landscape -a "http://example.com/*"', function() {
+        it('should try to config the project', function() {
+            cli.argv({ _: ['config'], p:'orientation=landscape',a:'http://example.com/*'});
+            expect(phonegap.config).toHaveBeenCalledWith({
+                preference: [{ name:'orientation', value:'landscape'}],
+                access: ['http://example.com/*']
+            },
+            jasmine.any(Function));
+        });
+	});
+});

--- a/spec/cli/create.spec.js
+++ b/spec/cli/create.spec.js
@@ -15,6 +15,7 @@ describe('phonegap help create', function() {
     beforeEach(function() {
         cli = new CLI();
         spyOn(process.stdout, 'write');
+        spyOn(process.stderr, 'write');
         stdout = process.stdout.write;
     });
 

--- a/spec/cli/help.spec.js
+++ b/spec/cli/help.spec.js
@@ -13,6 +13,7 @@ describe('phonegap help', function() {
     beforeEach(function() {
         cli = new CLI();
         spyOn(process.stdout, 'write');
+        spyOn(process.stderr, 'write');
     });
 
     describe('$ phonegap', function() {

--- a/spec/cli/install.spec.js
+++ b/spec/cli/install.spec.js
@@ -15,6 +15,7 @@ describe('phonegap help install', function() {
     beforeEach(function() {
         cli = new CLI();
         spyOn(process.stdout, 'write');
+        spyOn(process.stderr, 'write');
         stdout = process.stdout.write;
     });
 

--- a/spec/cli/local.build.spec.js
+++ b/spec/cli/local.build.spec.js
@@ -17,6 +17,7 @@ describe('phonegap help local build', function() {
         cli = new CLI();
         spyOn(phonegap.local, 'build');
         spyOn(process.stdout, 'write');
+        spyOn(process.stderr, 'write');
         stdout = process.stdout.write;
     });
 
@@ -76,6 +77,7 @@ describe('phonegap local build <platform>', function() {
             }
         };
         spyOn(process.stdout, 'write');
+        spyOn(process.stderr, 'write');
         spyOn(phonegap.local, 'build').andReturn(emitterSpy);
     });
 

--- a/spec/cli/local.install.spec.js
+++ b/spec/cli/local.install.spec.js
@@ -16,6 +16,7 @@ describe('phonegap help local install', function() {
         cli = new CLI();
         spyOn(phonegap.local, 'install');
         spyOn(process.stdout, 'write');
+        spyOn(process.stderr, 'write');
         stdout = process.stdout.write;
     });
 
@@ -70,6 +71,7 @@ describe('phonegap local install <platform>', function() {
     beforeEach(function() {
         cli = new CLI();
         spyOn(process.stdout, 'write');
+        spyOn(process.stderr, 'write');
         spyOn(phonegap.local, 'install');
     });
 

--- a/spec/cli/local.plugin.add.spec.js
+++ b/spec/cli/local.plugin.add.spec.js
@@ -16,6 +16,7 @@ describe('phonegap help local plugin add', function() {
         cli = new CLI();
         spyOn(process.stdout, 'write');
         stdout = process.stdout.write;
+        spyOn(process.stderr, 'write');
         spyOn(phonegap.local.plugin, 'add');
     });
 

--- a/spec/cli/local.plugin.list.spec.js
+++ b/spec/cli/local.plugin.list.spec.js
@@ -16,6 +16,7 @@ describe('phonegap help local plugin list', function() {
         cli = new CLI();
         spyOn(phonegap.local.plugin, 'list');
         spyOn(process.stdout, 'write');
+        spyOn(process.stderr, 'write');
         stdout = process.stdout.write;
     });
 

--- a/spec/cli/local.plugin.remove.spec.js
+++ b/spec/cli/local.plugin.remove.spec.js
@@ -16,6 +16,7 @@ describe('phonegap help local plugin remove', function() {
         cli = new CLI();
         spyOn(phonegap.local.plugin, 'remove');
         spyOn(process.stdout, 'write');
+        spyOn(process.stderr, 'write');
         stdout = process.stdout.write;
     });
 

--- a/spec/cli/local.plugin.spec.js
+++ b/spec/cli/local.plugin.spec.js
@@ -16,6 +16,7 @@ describe('phonegap help local plugin', function() {
         cli = new CLI();
         //spyOn(phonegap.local, 'plugin');
         spyOn(process.stdout, 'write');
+        spyOn(process.stderr, 'write');
         stdout = process.stdout.write;
     });
 

--- a/spec/cli/local.run.spec.js
+++ b/spec/cli/local.run.spec.js
@@ -16,6 +16,7 @@ describe('phonegap help local run', function() {
         cli = new CLI();
         spyOn(phonegap.local, 'run');
         spyOn(process.stdout, 'write');
+        spyOn(process.stderr, 'write');
         stdout = process.stdout.write;
     });
 

--- a/spec/cli/local.spec.js
+++ b/spec/cli/local.spec.js
@@ -14,6 +14,7 @@ describe('phonegap help local', function() {
     beforeEach(function() {
         cli = new CLI();
         spyOn(process.stdout, 'write');
+        spyOn(process.stderr, 'write');
         stdout = process.stdout.write;
     });
 

--- a/spec/cli/platform.spec.js
+++ b/spec/cli/platform.spec.js
@@ -14,6 +14,7 @@ describe('phonegap help platform', function() {
     beforeEach(function() {
         cli = new CLI();
         spyOn(process.stdout, 'write');
+        spyOn(process.stderr, 'write');
         stdout = process.stdout.write;
     });
 

--- a/spec/cli/platform.update.spec.js
+++ b/spec/cli/platform.update.spec.js
@@ -17,6 +17,7 @@ describe('phonegap help platform update', function() {
         cli = new CLI();
         spyOn(phonegap.platform, 'update');
         spyOn(process.stdout, 'write');
+        spyOn(process.stderr, 'write');
         stdout = process.stdout.write;
     });
 

--- a/spec/cli/plugin.add.spec.js
+++ b/spec/cli/plugin.add.spec.js
@@ -1,0 +1,118 @@
+/*
+ * Module dependencies.
+ */
+
+var phonegap = require('../../lib/main'),
+    CLI = require('../../lib/cli'),
+    cli,
+    stdout;
+
+/*
+ * Specification: $ phonegap help plugin add
+ */
+
+describe('phonegap help plugin add', function() {
+    beforeEach(function() {
+        cli = new CLI();
+        spyOn(process.stdout, 'write');
+        stdout = process.stdout.write;
+        spyOn(process.stderr, 'write');
+        spyOn(phonegap.plugin, 'add');
+    });
+
+    describe('$ phonegap help plugin', function() {
+        it('should include the command', function() {
+            cli.argv({ _: ['help', 'plugin'] });
+            expect(stdout.mostRecentCall.args[0]).toMatch(/\r?\n\s+add <path>.*\r?\n/i);
+        });
+    });
+
+    describe('$ phonegap plugin add', function() {
+        it('outputs usage info', function() {
+            cli.argv({ _: ['plugin', 'add'] });
+            expect(stdout.mostRecentCall.args[0]).toMatch(/usage: [\S]+ plugin add <path>/i);
+        });
+    });
+
+    describe('$ phonegap help plugin add', function() {
+        it('should output usage info', function() {
+            cli.argv({ _: ['help', 'plugin', 'add'] });
+            expect(stdout.mostRecentCall.args[0]).toMatch(/usage: [\S]+ plugin add <path>/i);
+        });
+    });
+
+    describe('$ phonegap plugin add help', function() {
+        it('should output usage info', function() {
+            cli.argv({ _: ['plugin', 'add', 'help'] });
+            expect(stdout.mostRecentCall.args[0]).toMatch(/usage: [\S]+ plugin add <path>/i);
+        });
+    });
+
+    describe('$ phonegap plugin add --help', function() {
+        it('should output usage info', function() {
+            cli.argv({ _: ['plugin', 'add'], help: true });
+            expect(stdout.mostRecentCall.args[0]).toMatch(/usage: [\S]+ plugin add <path>/i);
+        });
+    });
+
+    describe('$ phonegap plugin add -h', function() {
+        it('should output usage info', function() {
+            cli.argv({ _: ['plugin', 'add'], h: true });
+            expect(stdout.mostRecentCall.args[0]).toMatch(/usage: [\S]+ plugin add <path>/i);
+        });
+    });
+});
+
+/*
+ * Specification: $ phonegap plugin add <path>
+ */
+
+describe('phonegap plugin add <path>', function() {
+    beforeEach(function() {
+        cli = new CLI();
+        spyOn(process.stdout, 'write');
+        spyOn(phonegap.plugin, 'add');
+    });
+
+    describe('$ phonegap plugin add /path/to/plugin', function() {
+        it('should try to add the plugin', function() {
+            cli.argv({ _: ['plugin', 'add', '/path/to/plugin'] });
+            expect(phonegap.plugin.add).toHaveBeenCalledWith(
+                {
+                    path: ['/path/to/plugin']
+                },
+                jasmine.any(Function)
+            );
+        });
+
+        describe('successfully add plugin', function() {
+            beforeEach(function() {
+                phonegap.plugin.add.andCallFake(function(options, callback) {
+                    callback(null);
+                });
+            });
+
+            it('should call callback without an error', function(done) {
+                cli.argv({ _: ['plugin', 'add', '/path/to/plugin'] }, function(e, data) {
+                    expect(e).toBeNull();
+                    done();
+                });
+            });
+        });
+
+        describe('failed plugin add', function() {
+            beforeEach(function() {
+                phonegap.plugin.add.andCallFake(function(options, callback) {
+                    callback(new Error('write access denied'));
+                });
+            });
+
+            it('should call callback with an error', function(done) {
+                cli.argv({ _: ['plugin', 'add', 'android'] }, function(e) {
+                    expect(e).toEqual(jasmine.any(Error));
+                    done();
+                });
+            });
+        });
+    });
+});

--- a/spec/cli/plugin.list.spec.js
+++ b/spec/cli/plugin.list.spec.js
@@ -1,0 +1,109 @@
+/*
+ * Module dependencies.
+ */
+
+var phonegap = require('../../lib/main'),
+    CLI = require('../../lib/cli'),
+    cli,
+    stdout;
+
+/*
+ * Specification: $ phonegap help plugin list
+ */
+
+describe('phonegap help plugin list', function() {
+    beforeEach(function() {
+        cli = new CLI();
+        spyOn(phonegap.plugin, 'list');
+        spyOn(process.stdout, 'write');
+        spyOn(process.stderr, 'write');
+        stdout = process.stdout.write;
+    });
+
+    describe('$ phonegap help plugin', function() {
+        it('should include the command', function() {
+            cli.argv({ _: ['help', 'plugin'] });
+            expect(stdout.mostRecentCall.args[0]).toMatch(/\r?\n\s+list.*\r?\n/i);
+        });
+    });
+
+    describe('$ phonegap help plugin list', function() {
+        it('should output usage info', function() {
+            cli.argv({ _: ['help', 'plugin', 'list'] });
+            expect(stdout.mostRecentCall.args[0]).toMatch(/usage: [\S]+ plugin list/i);
+        });
+    });
+
+    describe('$ phonegap plugin list help', function() {
+        it('should output usage info', function() {
+            cli.argv({ _: ['plugin', 'list', 'help'] });
+            expect(stdout.mostRecentCall.args[0]).toMatch(/usage: [\S]+ plugin list/i);
+        });
+    });
+
+    describe('$ phonegap plugin list --help', function() {
+        it('should output usage info', function() {
+            cli.argv({ _: ['plugin', 'list'], help: true });
+            expect(stdout.mostRecentCall.args[0]).toMatch(/usage: [\S]+ plugin list/i);
+        });
+    });
+
+    describe('$ phonegap plugin list -h', function() {
+        it('should output usage info', function() {
+            cli.argv({ _: ['plugin', 'list'], h: true });
+            expect(stdout.mostRecentCall.args[0]).toMatch(/usage: [\S]+ plugin list/i);
+        });
+    });
+});
+
+/*
+ * Specification: $ phonegap plugin list
+ */
+
+describe('phonegap plugin list', function() {
+    beforeEach(function() {
+        cli = new CLI();
+        spyOn(process.stdout, 'write');
+        spyOn(phonegap.plugin, 'list');
+    });
+
+    describe('$ phonegap plugin list', function() {
+        it('should try to list the plugins', function() {
+            cli.argv({ _: ['plugin', 'list'] });
+            expect(phonegap.plugin.list).toHaveBeenCalledWith(
+                {},
+                jasmine.any(Function)
+            );
+        });
+
+        describe('successful plugin list', function() {
+            beforeEach(function() {
+                phonegap.plugin.list.andCallFake(function(options, callback) {
+                    callback(null);
+                });
+            });
+
+            it('should call callback without an error', function(done) {
+                cli.argv({ _: ['plugin', 'list'] }, function(e, data) {
+                    expect(e).toBeNull();
+                    done();
+                });
+            });
+        });
+
+        describe('failed plugin list', function() {
+            beforeEach(function() {
+                phonegap.plugin.list.andCallFake(function(options, callback) {
+                    callback(new Error('write access denied'));
+                });
+            });
+
+            it('should call callback with an error', function(done) {
+                cli.argv({ _: ['plugin', 'list'] }, function(e) {
+                    expect(e).toEqual(jasmine.any(Error));
+                    done();
+                });
+            });
+        });
+    });
+});

--- a/spec/cli/plugin.remove.spec.js
+++ b/spec/cli/plugin.remove.spec.js
@@ -1,0 +1,118 @@
+/*
+ * Module dependencies.
+ */
+
+var phonegap = require('../../lib/main'),
+    CLI = require('../../lib/cli'),
+    cli,
+    stdout;
+
+/*
+ * Specification: $ phonegap help plugin remove
+ */
+
+describe('phonegap help plugin remove', function() {
+    beforeEach(function() {
+        cli = new CLI();
+        spyOn(process.stdout, 'write');
+        stdout = process.stdout.write;
+        spyOn(process.stderr, 'write');
+        spyOn(phonegap.plugin, 'remove');
+    });
+
+    describe('$ phonegap help plugin', function() {
+        it('should include the command', function() {
+            cli.argv({ _: ['help', 'plugin'] });
+            expect(stdout.mostRecentCall.args[0]).toMatch(/\r?\n\s+remove <id>.*\r?\n/i);
+        });
+    });
+
+    describe('$ phonegap plugin remove', function() {
+        it('outputs usage info', function() {
+            cli.argv({ _: ['plugin', 'remove'] });
+            expect(stdout.mostRecentCall.args[0]).toMatch(/usage: [\S]+ plugin remove <id>/i);
+        });
+    });
+
+    describe('$ phonegap help plugin remove', function() {
+        it('should output usage info', function() {
+            cli.argv({ _: ['help', 'plugin', 'remove'] });
+            expect(stdout.mostRecentCall.args[0]).toMatch(/usage: [\S]+ plugin remove <id>/i);
+        });
+    });
+
+    describe('$ phonegap plugin remove help', function() {
+        it('should output usage info', function() {
+            cli.argv({ _: ['plugin', 'remove', 'help'] });
+            expect(stdout.mostRecentCall.args[0]).toMatch(/usage: [\S]+ plugin remove <id>/i);
+        });
+    });
+
+    describe('$ phonegap plugin remove --help', function() {
+        it('should output usage info', function() {
+            cli.argv({ _: ['plugin', 'remove'], help: true });
+            expect(stdout.mostRecentCall.args[0]).toMatch(/usage: [\S]+ plugin remove <id>/i);
+        });
+    });
+
+    describe('$ phonegap plugin remove -h', function() {
+        it('should output usage info', function() {
+            cli.argv({ _: ['plugin', 'remove'], h: true });
+            expect(stdout.mostRecentCall.args[0]).toMatch(/usage: [\S]+ plugin remove <id>/i);
+        });
+    });
+});
+
+/*
+ * Specification: $ phonegap plugin remove <id>
+ */
+
+describe('phonegap plugin remove <id>', function() {
+    beforeEach(function() {
+        cli = new CLI();
+        spyOn(process.stdout, 'write');
+        spyOn(phonegap.plugin, 'remove');
+    });
+
+    describe('$ phonegap plugin remove plugin.id', function() {
+        it('should try to remove the plugin', function() {
+            cli.argv({ _: ['plugin', 'remove', 'plugin.id'] });
+            expect(phonegap.plugin.remove).toHaveBeenCalledWith(
+                {
+                    id: ['plugin.id']
+                },
+                jasmine.any(Function)
+            );
+        });
+
+        describe('successfully remove plugin', function() {
+            beforeEach(function() {
+                phonegap.plugin.remove.andCallFake(function(options, callback) {
+                    callback(null);
+                });
+            });
+
+            it('should call callback without an error', function(done) {
+                cli.argv({ _: ['plugin', 'remove', 'plugin.id'] }, function(e, data) {
+                    expect(e).toBeNull();
+                    done();
+                });
+            });
+        });
+
+        describe('failed plugin remove', function() {
+            beforeEach(function() {
+                phonegap.plugin.remove.andCallFake(function(options, callback) {
+                    callback(new Error('write access denied'));
+                });
+            });
+
+            it('should call callback with an error', function(done) {
+                cli.argv({ _: ['plugin', 'remove', 'plugin.id'] }, function(e) {
+                    expect(e).toEqual(jasmine.any(Error));
+                    done();
+                });
+            });
+        });
+    });
+});

--- a/spec/cli/plugin.spec.js
+++ b/spec/cli/plugin.spec.js
@@ -1,0 +1,83 @@
+/*
+ * Module dependencies.
+ */
+
+var CLI = require('../../lib/cli'),
+    cli,
+    stdout;
+
+/*
+ * Specification: $ phonegap help plugin
+ */
+
+describe('phonegap help plugin', function() {
+    beforeEach(function() {
+        cli = new CLI();
+        spyOn(process.stdout, 'write');
+        spyOn(process.stderr, 'write');
+        stdout = process.stdout.write;
+    });
+
+    describe('$ phonegap help', function() {
+        it('should include the command', function() {
+            cli.argv({ _: ['help'] });
+            expect(stdout.mostRecentCall.args[0]).toMatch(/\r?\n\s+plugin \[command\].*\r?\n/i);
+        });
+    });
+
+    describe('$ phonegap plugin', function() {
+        it('should output usage info', function() {
+            cli.argv({ _: ['plugin'] });
+            expect(stdout.mostRecentCall.args[0]).toMatch(/usage: [\S]+ plugin/i);
+        });
+    });
+
+    describe('$ phonegap help plugin', function() {
+        it('should output usage info', function() {
+            cli.argv({ _: ['help', 'plugin'] });
+            expect(stdout.mostRecentCall.args[0]).toMatch(/usage: [\S]+ plugin/i);
+        });
+    });
+
+    describe('$ phonegap plugin help', function() {
+        it('should output usage info', function() {
+            cli.argv({ _: ['plugin', 'help'] });
+            expect(stdout.mostRecentCall.args[0]).toMatch(/usage: [\S]+ plugin/i);
+        });
+    });
+
+    describe('$ phonegap plugin --help', function() {
+        it('should output usage info', function() {
+            cli.argv({ _: ['plugin'], help: true });
+            expect(stdout.mostRecentCall.args[0]).toMatch(/usage: [\S]+ plugin/i);
+        });
+    });
+
+    describe('$ phonegap plugin -h', function() {
+        it('should output usage info', function() {
+            cli.argv({ _: ['plugin'], h: true });
+            expect(stdout.mostRecentCall.args[0]).toMatch(/usage: [\S]+ plugin/i);
+        });
+    });
+});
+
+/*
+ * Specification: $ phonegap plugin [command]
+ */
+
+describe('phonegap plugin <command>', function() {
+    beforeEach(function() {
+        cli = new CLI();
+    });
+
+    describe('unknown command', function() {
+        it('should output the unknown command', function() {
+            spyOn(cli, 'unknown');
+            cli.argv({ _: ['plugin', 'noop'] });
+            expect(cli.unknown).toHaveBeenCalledWith(
+                { _: ['plugin', 'noop'] },
+                jasmine.any(Function)
+            );
+        });
+    });
+});

--- a/spec/cli/remote.build.spec.js
+++ b/spec/cli/remote.build.spec.js
@@ -16,6 +16,7 @@ describe('phonegap help remote build', function() {
         cli = new CLI();
         spyOn(phonegap.remote, 'build');
         spyOn(process.stdout, 'write');
+        spyOn(process.stderr, 'write');
         stdout = process.stdout.write;
     });
 

--- a/spec/cli/remote.install.spec.js
+++ b/spec/cli/remote.install.spec.js
@@ -16,6 +16,7 @@ describe('phonegap help remote install', function() {
         cli = new CLI();
         spyOn(phonegap.remote, 'install');
         spyOn(process.stdout, 'write');
+        spyOn(process.stderr, 'write');
         stdout = process.stdout.write;
     });
 

--- a/spec/cli/remote.login.spec.js
+++ b/spec/cli/remote.login.spec.js
@@ -16,6 +16,7 @@ describe('phonegap help remote login', function() {
     beforeEach(function() {
         cli = new CLI();
         spyOn(process.stdout, 'write');
+        spyOn(process.stderr, 'write');
         stdout = process.stdout.write;
     });
 

--- a/spec/cli/remote.logout.spec.js
+++ b/spec/cli/remote.logout.spec.js
@@ -15,6 +15,7 @@ describe('phonegap help remote logout', function() {
     beforeEach(function() {
         cli = new CLI();
         spyOn(process.stdout, 'write');
+        spyOn(process.stderr, 'write');
         stdout = process.stdout.write;
     });
 

--- a/spec/cli/remote.run.spec.js
+++ b/spec/cli/remote.run.spec.js
@@ -16,6 +16,7 @@ describe('phonegap help remote run', function() {
         cli = new CLI();
         spyOn(phonegap.remote, 'run');
         spyOn(process.stdout, 'write');
+        spyOn(process.stderr, 'write');
         stdout = process.stdout.write;
     });
 

--- a/spec/cli/remote.spec.js
+++ b/spec/cli/remote.spec.js
@@ -14,6 +14,7 @@ describe('phonegap help remote', function() {
     beforeEach(function() {
         cli = new CLI();
         spyOn(process.stdout, 'write');
+        spyOn(process.stderr, 'write');
         stdout = process.stdout.write;
     });
 

--- a/spec/cli/run.spec.js
+++ b/spec/cli/run.spec.js
@@ -15,6 +15,7 @@ describe('phonegap help run', function() {
     beforeEach(function() {
         cli = new CLI();
         spyOn(process.stdout, 'write');
+        spyOn(process.stderr, 'write');
         stdout = process.stdout.write;
     });
 

--- a/spec/cli/serve.spec.js
+++ b/spec/cli/serve.spec.js
@@ -1,0 +1,110 @@
+/*
+ * Module dependencies.
+ */
+
+var phonegap = require('../../lib/main'),
+    CLI = require('../../lib/cli'),
+    cli,
+    stdout;
+
+/*
+ * Specification: $ phonegap help serve
+ */
+
+describe('phonegap help serve', function() {
+    beforeEach(function() {
+        cli = new CLI();
+        spyOn(phonegap, 'serve');
+        spyOn(process.stdout, 'write');
+        spyOn(process.stderr, 'write');
+        stdout = process.stdout.write;
+    });
+
+    describe('$ phonegap help', function() {
+        it('should not include the command', function() {
+            cli.argv({ _: ['help'] });
+            expect(stdout.mostRecentCall.args[0]).not.toMatch(/\r?\n\s+serve.*\r?\n/i);
+        });
+    });
+
+    describe('$ phonegap help serve', function() {
+        it('should output usage info', function() {
+            cli.argv({ _: ['help', 'serve'] });
+            expect(stdout.mostRecentCall.args[0]).toMatch(/usage: [\S]+ serve/i);
+        });
+    });
+
+    describe('$ phonegap serve help', function() {
+        it('should output usage info', function() {
+            cli.argv({ _: ['serve', 'help'] });
+            expect(stdout.mostRecentCall.args[0]).toMatch(/usage: [\S]+ serve/i);
+        });
+    });
+
+    describe('$ phonegap serve --help', function() {
+        it('should output usage info', function() {
+            cli.argv({ _: ['serve'], help: true });
+            expect(stdout.mostRecentCall.args[0]).toMatch(/usage: [\S]+ serve/i);
+        });
+    });
+
+    describe('$ phonegap serve -h', function() {
+        it('should output usage info', function() {
+            cli.argv({ _: ['serve'], h: true });
+            expect(stdout.mostRecentCall.args[0]).toMatch(/usage: [\S]+ serve/i);
+        });
+    });
+});
+
+/*
+ * Specification: $ phonegap serve
+ */
+
+describe('phonegap serve', function() {
+    beforeEach(function() {
+        cli = new CLI();
+        spyOn(process.stdout, 'write');
+        spyOn(phonegap, 'serve').andReturn({
+            on: function(){}
+        });
+    });
+
+    describe('$ phonegap serve', function() {
+        it('should connect to phonegap serve', function() {
+            cli.argv({ _: ['serve'] });
+            expect(phonegap.serve).toHaveBeenCalled();
+        });
+    });
+
+    describe('$ phonegap serve --port 1337', function() {
+        it('should connect to phonegap serve on port 1337', function() {
+            cli.argv({ _: ['serve'], port: 1337 });
+            expect(phonegap.serve).toHaveBeenCalled();
+            expect(phonegap.serve.mostRecentCall.args[0]).toEqual({ port: 1337 });
+        });
+    });
+
+    describe('$ phonegap serve -p 1337', function() {
+        it('should connect to phonegap serve on port 1337', function() {
+            cli.argv({ _: ['serve'], p: 1337 });
+            expect(phonegap.serve).toHaveBeenCalled();
+            expect(phonegap.serve.mostRecentCall.args[0]).toEqual({ port: 1337 });
+        });
+    });
+
+    describe('$ phonegap serve --autoreload', function() {
+        it('should enable autoreload', function() {
+            cli.argv({ _: ['serve'], autoreload: true });
+            expect(phonegap.serve).toHaveBeenCalled();
+            expect(phonegap.serve.mostRecentCall.args[0]).toEqual({ autoreload: true });
+        });
+    });
+
+    describe('$ phonegap serve --no-autoreload', function() {
+        it('should disable autoreload', function() {
+            cli.argv({ _: ['serve'], autoreload: false });
+            expect(phonegap.serve).toHaveBeenCalled();
+            expect(phonegap.serve.mostRecentCall.args[0]).toEqual({ autoreload: false });
+        });
+    });
+});

--- a/spec/cli/unknown.spec.js
+++ b/spec/cli/unknown.spec.js
@@ -13,6 +13,8 @@ describe('phonegap unknown', function() {
     beforeEach(function() {
         cli = new CLI();
         spyOn(process.stdout, 'write');
+        spyOn(process.stderr, 'write');
+
     });
 
     describe('$ phonegap noop', function() {

--- a/spec/cli/verbose.spec.js
+++ b/spec/cli/verbose.spec.js
@@ -16,7 +16,8 @@ describe('phonegap --verbose <command>', function() {
         spyOn(phonegap, 'build');
         spyOn(phonegap, 'mode');
         spyOn(process.stdout, 'write');
-    });
+        spyOn(process.stderr, 'write');
+   });
 
     describe('$ phonegap --verbose <command>', function() {
         it('should enable verbose mode', function() {
@@ -29,7 +30,7 @@ describe('phonegap --verbose <command>', function() {
 
     describe('$ phonegap -V <command>', function() {
         it('should enable verbose mode', function() {
-            cli.argv({ _: ['build', 'android'], V: true });
+            cli.argv({ _: ['build', 'android'], d: true });
             expect(phonegap.mode).toHaveBeenCalledWith({
                 verbose: true
             });

--- a/spec/cli/version.spec.js
+++ b/spec/cli/version.spec.js
@@ -14,6 +14,7 @@ describe('phonegap --version', function() {
     beforeEach(function() {
         cli = new CLI();
         spyOn(process.stdout, 'write');
+        spyOn(process.stderr, 'write');
         spyOn(phonegap, 'version').andReturn({
             npm: '2.8.0-0.10.6',
             module: '0.10.6',

--- a/spec/phonegap/app.spec.js
+++ b/spec/phonegap/app.spec.js
@@ -3,15 +3,7 @@
  */
 
 var PhoneGap = require('../../lib/phonegap'),
-    project = require('../../lib/phonegap/util/project'),
-    http = require('http'),
-    events = require('events'),
-    Static = require('node-static'),
-    serverSpy,
-    serveSpy,
-    phonegap,
-    request,
-    options;
+    phonegap;
 
 /*!
  * Specification: phonegap.app(options, [callback])
@@ -20,120 +12,9 @@ var PhoneGap = require('../../lib/phonegap'),
 describe('phonegap.app(options, [callback])', function() {
     beforeEach(function() {
         phonegap = new PhoneGap();
-        options = {};
-        spyOn(project, 'cd').andReturn(true);
-        // mock the http.createServer
-        spyOn(http, 'createServer').andCallFake(function(callback) {
-            request = new events.EventEmitter();
-            request.url = '/some/path';
-            serverSpy = new events.EventEmitter();
-            serverSpy.listen = jasmine.createSpy();
-            callback(request, { status: 200 }); // bind routes
-            return serverSpy;
-        });
-        // mock node-static
-        serveSpy = jasmine.createSpy('file.serve');
-        spyOn(Static, 'Server').andReturn({
-            serve: serveSpy
-        });
     });
 
-    it('should require options', function() {
-        expect(function() {
-            options = undefined;
-            phonegap.app(options, function(e) {});
-        }).toThrow();
-    });
-
-    it('should not require options.port', function() {
-        expect(function() {
-            options.port = undefined;
-            phonegap.app(options, function(e) {});
-        }).not.toThrow();
-    });
-
-    it('should not require callback', function() {
-        expect(function() {
-            phonegap.app(options);
-        }).not.toThrow();
-    });
-
-    it('should return itself', function() {
-        expect(phonegap.app(options)).toEqual(phonegap);
-    });
-
-    it('should change to project directory', function() {
-        phonegap.app(options);
-        expect(project.cd).toHaveBeenCalledWith({
-            emitter: phonegap,
-            callback: jasmine.any(Function)
-        });
-    });
-
-    it('should try to serve the project', function() {
-        phonegap.app(options);
-        expect(http.createServer).toHaveBeenCalled();
-    });
-
-    describe('when successfully started server', function() {
-        it('should listen on the default port (3000)', function() {
-            phonegap.app(options);
-            expect(serverSpy.listen).toHaveBeenCalledWith(3000);
-        });
-
-        it('should listen on the specified port', function() {
-            options.port = 1337;
-            phonegap.app(options);
-            expect(serverSpy.listen).toHaveBeenCalledWith(1337);
-        });
-
-        it('should trigger callback with server object', function(done) {
-            phonegap.app(options, function(e, server) {
-                expect(server).toEqual({
-                    address: '127.0.0.1',
-                    port: 3000
-                });
-                done();
-            });
-            serverSpy.emit('listening');
-        });
-
-        describe('on request', function() {
-            it('should serve a response', function() {
-                phonegap.app(options, function(e) {});
-                request.emit('end');
-                expect(serveSpy).toHaveBeenCalled();
-            });
-
-            it('should emit a "log" event', function(done) {
-                serveSpy.andCallFake(function(request, response, callback) {
-                    callback(null, { status: 200 });
-                });
-                phonegap.on('log', function(request, response) {
-                    done();
-                });
-                phonegap.app(options);
-                request.emit('end');
-            });
-        });
-    });
-
-    describe('when failed to start server', function() {
-        it('should trigger callback with an error', function(done) {
-            phonegap.app(options, function(e) {
-                expect(e).toEqual(jasmine.any(Error));
-                done();
-            });
-            serverSpy.emit('error', new Error('port in use'));
-        });
-
-        it('should fire "error" event', function(done) {
-            phonegap.on('error', function(e) {
-                expect(e).toEqual(jasmine.any(Error));
-                done();
-            });
-            phonegap.app(options);
-            serverSpy.emit('error', new Error('port in use'));
-        });
+    it('should use phonegap.serve', function() {
+        expect(phonegap.app).toEqual(phonegap.serve);
     });
 });

--- a/spec/phonegap/build.spec.js
+++ b/spec/phonegap/build.spec.js
@@ -32,6 +32,7 @@ describe('phonegap.build(options, [callback])', function() {
                 return qno;
             }
         }
+        spyOn(process.stderr, 'write');
         spyOn(phonegap.local, 'build').andReturn(phonegap);
         spyOn(phonegap.remote, 'build').andReturn(phonegap);
         spyOn(cordova.raw.platform, 'supports').andReturn(qyes);

--- a/spec/phonegap/create.spec.js
+++ b/spec/phonegap/create.spec.js
@@ -20,9 +20,10 @@ describe('phonegap.create(options, [callback])', function() {
         };
         spyOn(phonegap, 'version').andReturn({ phonegap: '2.8.0' });
         spyOn(cordova, 'create');
-        spyOn(cordova, 'config');
         spyOn(shell, 'rm');
         spyOn(shell, 'cp');
+
+        spyOn(process.stderr, 'write');
     });
 
     it('should require options', function() {
@@ -39,6 +40,13 @@ describe('phonegap.create(options, [callback])', function() {
         }).toThrow();
     });
 
+    it('should require accept a numeric path', function() {
+        expect(function() {
+            options.path = 123;
+            phonegap.create(options, function(e) {});
+        }).not.toThrow();
+    });
+
     it('should not require callback', function() {
         expect(function() {
             phonegap.create(options);
@@ -47,19 +55,6 @@ describe('phonegap.create(options, [callback])', function() {
 
     it('should return itself', function() {
         expect(phonegap.create(options)).toEqual(phonegap);
-    });
-
-    it('should use phonegap hello world app', function() {
-        phonegap.create(options);
-        expect(cordova.config).toHaveBeenCalledWith(options.path, {
-            lib: {
-                www: {
-                    id: 'phonegap',
-                    version: '2.8.0',
-                    uri: jasmine.any(String)
-                }
-            }
-        });
     });
 
     it('should try to create a project with default values', function() {

--- a/spec/phonegap/install.spec.js
+++ b/spec/phonegap/install.spec.js
@@ -29,6 +29,7 @@ describe('phonegap.install(options, [callback])', function() {
                 fail();
             }
         }
+        spyOn(process.stderr, 'write');
         spyOn(phonegap.local, 'install').andReturn(phonegap);
         spyOn(phonegap.remote, 'install').andReturn(phonegap);
         spyOn(cordova.raw.platform, 'supports').andReturn(qyes);

--- a/spec/phonegap/local.build.spec.js
+++ b/spec/phonegap/local.build.spec.js
@@ -21,6 +21,7 @@ describe('phonegap.local.build(options, [callback])', function() {
         options = {
             platforms: ['android']
         };
+        spyOn(process.stderr, 'write');
         spyOn(cordova, 'build');
         spyOn(localBuild, 'addPlatform');
         spyOn(project, 'cd').andReturn(true);
@@ -181,6 +182,7 @@ describe('localBuild.addPlatform(options, callback)', function() {
                 emit: function() {}
             }
         };
+        spyOn(process.stderr, 'write');
         spyOn(fs, 'existsSync');
         spyOn(cordova, 'platform');
     });

--- a/spec/phonegap/local.install.spec.js
+++ b/spec/phonegap/local.install.spec.js
@@ -19,6 +19,7 @@ describe('phonegap.local.install(options, [callback])', function() {
             platforms: ['android']
         };
         spyOn(process.stdout, 'write');
+        spyOn(process.stderr, 'write');
         spyOn(project, 'cd').andReturn(true);
         spyOn(cordova, 'emulate');
         spyOn(cordova, 'run');

--- a/spec/phonegap/local.plugin.add.spec.js
+++ b/spec/phonegap/local.plugin.add.spec.js
@@ -18,6 +18,8 @@ describe('phonegap.local.plugin.add(options, [callback])', function() {
         options = {
             path: ['/path/to/plugin']
         };
+        spyOn(process.stdout, 'write');
+        spyOn(process.stderr, 'write');
         spyOn(cordova, 'plugin');
         spyOn(project, 'cd').andReturn(true);
     });

--- a/spec/phonegap/local.plugin.list.spec.js
+++ b/spec/phonegap/local.plugin.list.spec.js
@@ -16,6 +16,7 @@ describe('phonegap.local.plugin.list(options, [callback])', function() {
     beforeEach(function() {
         phonegap = new PhoneGap();
         options = {};
+        spyOn(process.stderr, 'write');
         spyOn(cordova, 'plugin');
         spyOn(project, 'cd').andReturn(true);
     });
@@ -47,17 +48,13 @@ describe('phonegap.local.plugin.list(options, [callback])', function() {
 
     it('should try to list the plugins', function() {
         phonegap.local.plugin.list(options);
-        expect(cordova.plugin).toHaveBeenCalledWith(
-            'list',
-            [],
-            jasmine.any(Function)
-        );
+        expect(cordova.plugin).toHaveBeenCalledWith('list');
     });
 
     describe('successfully list plugins', function() {
         beforeEach(function() {
             cordova.plugin.andCallFake(function(command, targets, callback) {
-                callback(null, [
+                cordova.emit('results', [
                     'org.cordova.core.geolocation',
                     'org.cordova.core.contacts'
                 ]);
@@ -82,10 +79,13 @@ describe('phonegap.local.plugin.list(options, [callback])', function() {
         });
     });
 
+    //
+    // cordova does not support an error state, but this is for the future
+    //
     describe('failed to list plugins', function() {
         beforeEach(function() {
             cordova.plugin.andCallFake(function(command, targets, callback) {
-                callback(new Error('read access denied'));
+                cordova.emit('results', new Error('read access denied'));
             });
         });
 

--- a/spec/phonegap/local.plugin.remove.spec.js
+++ b/spec/phonegap/local.plugin.remove.spec.js
@@ -18,6 +18,7 @@ describe('phonegap.local.plugin.remove(options, [callback])', function() {
         options = {
             id: ['org.apache.core.geolocation']
         };
+        spyOn(process.stderr, 'write');
         spyOn(cordova, 'plugin');
         spyOn(project, 'cd').andReturn(true);
     });

--- a/spec/phonegap/local.run.spec.js
+++ b/spec/phonegap/local.run.spec.js
@@ -17,6 +17,7 @@ describe('phonegap.local.run(options, [callback])', function() {
         options = {
             platforms: ['android']
         };
+        spyOn(process.stderr, 'write');
         spyOn(process.stdout, 'write');
         spyOn(phonegap.local, 'build');
         spyOn(phonegap.local, 'install');

--- a/spec/phonegap/platform.update.spec.js
+++ b/spec/phonegap/platform.update.spec.js
@@ -19,6 +19,7 @@ describe('phonegap.platform.update(options, [callback])', function() {
         options = {
             platforms: ['android']
         };
+        spyOn(process.stderr, 'write');
         spyOn(cordova, 'platform');
         spyOn(project, 'cd').andReturn(true);
     });

--- a/spec/phonegap/plugin.add.spec.js
+++ b/spec/phonegap/plugin.add.spec.js
@@ -1,0 +1,20 @@
+/*!
+ * Module dependencies.
+ */
+
+var PhoneGap = require('../../lib/phonegap'),
+    phonegap;
+
+/*!
+ * Specification: phonegap.plugin.add(options, [callback])
+ */
+
+describe('phonegap.plugin.add(options, [callback])', function() {
+    beforeEach(function() {
+        phonegap = new PhoneGap();
+    });
+
+    it('should use phonegap.local.plugin.add', function() {
+        expect(phonegap.plugin.add).toEqual(phonegap.local.plugin.add);
+    });
+});

--- a/spec/phonegap/plugin.list.spec.js
+++ b/spec/phonegap/plugin.list.spec.js
@@ -1,0 +1,20 @@
+/*!
+ * Module dependencies.
+ */
+
+var PhoneGap = require('../../lib/phonegap'),
+    phonegap;
+
+/*!
+ * Specification: phonegap.plugin.list(options, [callback])
+ */
+
+describe('phonegap.plugin.list(options, [callback])', function() {
+    beforeEach(function() {
+        phonegap = new PhoneGap();
+    });
+
+    it('should use phonegap.local.plugin.list', function() {
+        expect(phonegap.plugin.list).toEqual(phonegap.local.plugin.list);
+    });
+});

--- a/spec/phonegap/plugin.remove.spec.js
+++ b/spec/phonegap/plugin.remove.spec.js
@@ -1,0 +1,20 @@
+/*!
+ * Module dependencies.
+ */
+
+var PhoneGap = require('../../lib/phonegap'),
+    phonegap;
+
+/*!
+ * Specification: phonegap.plugin.remove(options, [callback])
+ */
+
+describe('phonegap.plugin.remove(options, [callback])', function() {
+    beforeEach(function() {
+        phonegap = new PhoneGap();
+    });
+
+    it('should use phonegap.local.plugin.remove', function() {
+        expect(phonegap.plugin.remove).toEqual(phonegap.local.plugin.remove);
+    });
+});

--- a/spec/phonegap/remote.build.spec.js
+++ b/spec/phonegap/remote.build.spec.js
@@ -29,6 +29,7 @@ describe('phonegap.remote.build(options, [callback])', function() {
             }
         };
         spyOn(process.stdout, 'write');
+        spyOn(process.stderr, 'write');
         spyOn(phonegap.remote, 'login');
         spyOn(phonegapbuild, 'build');
         spyOn(project, 'cd').andReturn(true);

--- a/spec/phonegap/remote.install.spec.js
+++ b/spec/phonegap/remote.install.spec.js
@@ -20,6 +20,7 @@ describe('phonegap.remote.install(options, [callback])', function() {
             platforms: ['android']
         };
         spyOn(process.stdout, 'write');
+        spyOn(process.stderr, 'write');
         spyOn(project, 'cd').andReturn(true);
     });
 

--- a/spec/phonegap/remote.login.spec.js
+++ b/spec/phonegap/remote.login.spec.js
@@ -16,6 +16,7 @@ describe('phonegap.remote.login(options, [callback])', function() {
     beforeEach(function() {
         phonegap = new PhoneGap();
         options = {};
+        spyOn(process.stderr, 'write');
         spyOn(phonegapbuild, 'login');
         spyOn(config.global, 'load');
     });

--- a/spec/phonegap/remote.logout.spec.js
+++ b/spec/phonegap/remote.logout.spec.js
@@ -15,6 +15,7 @@ describe('phonegap.remote.logout(options, [callback])', function() {
     beforeEach(function() {
         phonegap = new PhoneGap();
         options = {};
+        spyOn(process.stderr, 'write');
         spyOn(phonegapbuild, 'logout');
     });
 

--- a/spec/phonegap/remote.run.spec.js
+++ b/spec/phonegap/remote.run.spec.js
@@ -21,6 +21,7 @@ describe('phonegap.remote.run(options, [callback])', function() {
             platforms: ['android']
         };
         spyOn(process.stdout, 'write');
+        spyOn(process.stderr, 'write');
         spyOn(phonegap.remote, 'build');
         spyOn(project, 'cd').andReturn(true);
     });

--- a/spec/phonegap/serve.spec.js
+++ b/spec/phonegap/serve.spec.js
@@ -1,0 +1,123 @@
+/*!
+ * Module dependencies.
+ */
+
+var PhoneGap = require('../../lib/phonegap'),
+    project = require('../../lib/phonegap/util/project'),
+    events = require('events'),
+    soundwave = require('phonegap-soundwave'),
+    phonegap,
+    options;
+
+/*!
+ * Specification: phonegap.serve(options, [callback])
+ */
+
+describe('phonegap.serve(options, [callback])', function() {
+    beforeEach(function() {
+        phonegap = new PhoneGap();
+        options = {};
+        spyOn(project, 'cd').andReturn(true);     
+        spyOn(soundwave,'serve');
+        spyOn(soundwave,'on').andCallThrough();
+    });
+
+    it('should require options', function() {
+        expect(function() {
+            options = undefined;
+            phonegap.serve(options, function(e) {});
+        }).toThrow();
+    });
+
+    it('should not require options.port', function() {
+        expect(function() {
+            options.port = undefined;
+            phonegap.serve(options, function(e) {});
+        }).not.toThrow();
+    });
+
+    it('should not require callback', function() {
+        expect(function() {
+            phonegap.serve(options);
+        }).not.toThrow();
+    });
+
+    it('should return itself', function() {
+        expect(phonegap.serve(options)).toEqual(phonegap);
+    });
+
+    it('should change to project directory', function() {
+        phonegap.serve(options);
+        expect(project.cd).toHaveBeenCalledWith({
+            emitter: phonegap,
+            callback: jasmine.any(Function)
+        });
+    });
+
+    it('should try to serve the project', function() {
+        phonegap.serve(options);
+        expect(soundwave.serve).toHaveBeenCalled();
+    });
+
+    describe('when successfully started server', function() {
+        beforeEach(function() {
+            soundwave.serve.andCallFake(function(options, callback) {
+                callback(null, {
+                    address: '127.0.0.1',
+                    port: 3000
+                });
+            });
+        });
+
+        it('should fire callback without an error', function(done) {
+            phonegap.serve(options, function(e, server) {
+                expect(e).toBeNull();
+                done();
+            });
+        });
+
+        it('should fire callback with server options', function(done) {
+            phonegap.serve(options, function(e, server) {
+                expect(server).toEqual(jasmine.any(Object));
+                done();
+            });
+        });
+
+        describe('on request and response', function() {
+            it('should trigger a "log" event', function(done) {
+                phonegap.on('log', function(message) {
+                    expect(message).toEqual(jasmine.any(String));
+                    done();
+                });
+                phonegap.serve(options);
+                soundwave.emit('log', '201 /path/to/a/file.html');
+            });
+        });
+    });
+
+    describe('when failed to start server', function() {
+        beforeEach(function() {
+            soundwave.serve.andCallFake(function(options, callback) {
+                var e = new Error('port in use');
+                //soundwave.on('error', function() {});
+                //soundwave.emit('error', e);
+                callback(e);
+            });
+        });
+
+        it('should fire callback with an error', function(done) {
+            phonegap.serve(options, function(e, server) {
+                expect(e).toEqual(jasmine.any(Error));
+                done();
+            });
+        });
+
+        //it('should trigger error event', function(done) {
+        //    phonegap.on('error', function(e, server) {
+        //        expect(e).toEqual(jasmine.any(Error));
+        //        done();
+        //    });
+        //    phonegap.serve(options);
+        //});
+    });
+});

--- a/spec/phonegap/util/platform.spec.js
+++ b/spec/phonegap/util/platform.spec.js
@@ -75,20 +75,6 @@ describe('platform', function() {
                     expect(platforms[0].local).toEqual('android');
                 });
             });
-
-            describe('symbian', function() {
-                beforeEach(function() {
-                    platforms = ['symbian'];
-                });
-
-                it('should support remote', function() {
-                    platforms = platform.names(platforms);
-                    expect(platforms.length).toEqual(1);
-                    expect(platforms[0].local).toBe(null);
-                    expect(platforms[0].remote).toBe('symbian');
-                    expect(platforms[0].human).toBe('Symbian');
-                });
-            });
         });
     });
 });

--- a/spec/phonegap/util/project.spec.js
+++ b/spec/phonegap/util/project.spec.js
@@ -87,4 +87,25 @@ describe('project', function() {
             });
         });
     });
+    describe('clobbersConfig', function() {
+        var fixtureUri = '/User/dev/correct/uri/to/config',
+            fixtureContent = 'aabbcc';
+
+        beforeEach(function(){
+            createSpyObj('fs', ['open','readFile']);
+            spyOn(fs,'readFile').andReturn(null,'');
+        });
+
+        it('should be defined clue', function() {
+            expect(project.clobberProjectConfig).toBeDefined();
+        });
+        it('should return null if path is invalid', function () {
+            var res = project.clobberProjectConfig('blarg',{});
+        });
+        it('should return the path of the config file when successful', function () {
+            var res = project.clobberProjectConfig(fixtureUri, {'aa':'bb','cc':'bb'});
+
+            expect(res).toEqual(fixtureUri); 
+        });
+    });
 });


### PR DESCRIPTION
This PR allows the user to modify the preference tags on the config.xml file of the project using the command line, instead of requiring manual edition of the file. 
This is not limited to the existing preferences, it also allows to create new custom ones.
It will be very handy to automatic process to change the default orientation or force fullscreen or change the color of the status bar (ios) on a simple step.
It also allows to introduce new access directives, also handy to avoid using the \* by default.

Sample of usage:
phonegap config ./my-app -p orientation=landscape -a "http://myhost.com/*"
