### PR TITLE
bump Cordova version to 3.3.1-0.4.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "dependencies": {
         "colors": "0.6.0-1",
         "connect-phonegap": "0.8.1",
-        "cordova": "3.3.0-0.1.1",
+        "cordova": "3.3.1-0.4.2",
         "optimist": "0.6.0",
         "phonegap-build": "0.8.4",
         "pluralize": "0.0.4",


### PR DESCRIPTION
This makes the inAppBrowser plugin work.

[This Cordova issue may be related](https://issues.apache.org/jira/browse/CB-6008)
