### PR TITLE
Fixing phonegap local build with a temporary timeout workaround

### DIFF
--- a/lib/phonegap/local.build.js
+++ b/lib/phonegap/local.build.js
@@ -157,7 +157,14 @@ module.exports.addPlatform = function(options, callback) {
             return;
         }
 
-        callback(null);
+        // Temporary workaround fixes "phonegap local build [platform]"
+        // cordova starts building the mobile app before the entire "platform
+        // add" process is completed. Causes some files to not be included in
+        // built mobile project. Setting the timeout to a high number so that
+        // this would fix most build scenarios.
+        setTimeout(function(){
+            callback.call(self, null);
+        }, 5000);
     });
 };
 


### PR DESCRIPTION
This PR fixes the issues I was having when running `phonegap local build ios`

There is an issue with timing between cordova and phonegap-cli. Basically the callback when running `cordova.platform('add', ...)` is firing too quickly. The cordova platform build is starting before the platform is fully added. This most likely fixes: #237 and fixes: #252

This is a temporary fix until this issue is resolved properly. This most likely should be fixed in the underlying cordova project. The callback should not be fired until the platform add process is fully completed. 

[Problem file in cordova](https://git-wip-us.apache.org/repos/asf?p=cordova-cli.git;a=blob;f=src/platform.js;h=080ec3aab8b312a035ffe9db618aa03469571242;hb=HEAD)

I'm not very familiar with the cordova and phonegap code. Perhaps the platform add callback is fired before a necessary after_platform_add hook is completed? A filesystem async issue?
