### PR TITLE
npm install fails with "fatal: unable to connect to github.com" behind a strict firewall

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "dependencies": {
         "colors": "0.6.0-1",
         "cordova": "3.5.0-0.2.4",
-        "cordova-lib": "git://github.com/apache/cordova-lib.git#3623a84eb391f41c5a32ddc67eea89512c4ba654",
+        "cordova-lib": "git+https://github.com/apache/cordova-lib.git#3623a84eb391f41c5a32ddc67eea89512c4ba654",
         "connect-phonegap": "0.11.0",
         "minimist": "0.1.0",
         "phonegap-build": "0.8.4",


### PR DESCRIPTION
Use git+https:// instead of git:// to avoid problems with strict firewalls
