### PR TITLE
Firefox OS - Fix name and add to help

### DIFF
--- a/doc/cli/help.txt
+++ b/doc/cli/help.txt
@@ -29,9 +29,10 @@ Platforms:
   keyword            | local environment   | remote environment
   -------------------|---------------------|-------------------
   android            | Yes                 | Yes
+  blackberry         | Yes                 | No
+  firefoxos          | Yes                 | No
   ios                | Yes                 | Yes
   wp8                | Yes                 | Yes
-  Blackberry 10      | Yes                 | No 
 
 Examples:
 

--- a/lib/phonegap/util/platform.js
+++ b/lib/phonegap/util/platform.js
@@ -66,6 +66,6 @@ module.exports.map = {
     firefoxos: {
         local: 'firefoxos',
         remote: null,
-        human: 'Fire Fox OS'
+        human: 'Firefox OS'
     }
 };


### PR DESCRIPTION
Adding firefoxos platform to platforms table in help. I'm ordering alphabetically and fixed platform name for blackberry.
