### PR TITLE
Be able to pass the --target through the phonegap-cli

### DIFF
--- a/lib/phonegap/local.install.js
+++ b/lib/phonegap/local.install.js
@@ -35,6 +35,7 @@ util.inherits(LocalInstallCommand, Command);
  *     - `platforms` {Array} is a list of platforms (limited to 1).
  *     - [`device`] {Boolean} is true when only using device.
  *     - [`emulator`] {Boolean} is true when only using emulator.
+ *     - [`target`] {String} way to pass device arguments to emulator
  *   - [`callback`] {Function} is triggered after completion.
  *     - `e` {Error} is null unless there is an error.
  *
@@ -85,7 +86,12 @@ LocalInstallCommand.prototype.execute = function(options, callback) {
     else if (options.emulator) {
         self.phonegap.emit('log', 'installing app onto emulator');
         cordovaEmulate(self, platform);
-        self.phonegap.cordova.raw.emulate([ platform.local ], _callback);
+        emulate_opts = [ platform.local ];
+        if (options.target)  {
+            emulate_opts = {platforms: [ platform.local ],
+                            options: "--target="+options.target};
+        }
+        self.phonegap.cordova.raw.emulate(emulate_opts, _callback);
     }
     // when no target is specified: try device and fallback on emulator
     else {
@@ -95,7 +101,12 @@ LocalInstallCommand.prototype.execute = function(options, callback) {
                 self.phonegap.emit('log', 'no device was found');
                 self.phonegap.emit('log', 'trying to install app onto emulator');
                 cordovaEmulate(self, platform);
-                self.phonegap.cordova.raw.emulate([ platform.local ], function(e) {
+                emulate_opts = [ platform.local ];
+                if (options.target)  {
+                    emulate_opts = {platforms: [ platform.local ],
+                                    options: "--target="+options.target};
+                }
+                self.phonegap.cordova.raw.emulate(emulate_opts, function(e) {
                     if (!e) {
                         self.phonegap.emit('log', 'successfully installed onto emulator');
                     }

--- a/spec/phonegap/local.install.spec.js
+++ b/spec/phonegap/local.install.spec.js
@@ -54,6 +54,13 @@ describe('phonegap.local.install(options, [callback])', function() {
         }).not.toThrow();
     });
 
+    it('should not require options.target', function()  {
+        expect(function() {
+            options.target = undefined;
+            phonegap.local.install(options);
+        }).not.toThrow();
+    });
+
     it('should not require callback', function() {
         expect(function() {
             phonegap.local.install(options);
@@ -78,6 +85,16 @@ describe('phonegap.local.install(options, [callback])', function() {
         });
 
         it('should install the app to the device', function() {
+            phonegap.local.install(options);
+            expect(cordova.raw.run).toHaveBeenCalledWith(
+                options.platforms,
+                jasmine.any(Function)
+            );
+            expect(cordova.raw.emulate).not.toHaveBeenCalled();
+        });
+
+        it('should ignore target parameter', function() {
+            options.target = "sometarget";
             phonegap.local.install(options);
             expect(cordova.raw.run).toHaveBeenCalledWith(
                 options.platforms,
@@ -134,6 +151,16 @@ describe('phonegap.local.install(options, [callback])', function() {
             phonegap.local.install(options);
             expect(cordova.raw.emulate).toHaveBeenCalledWith(
                 options.platforms,
+                jasmine.any(Function)
+            );
+            expect(cordova.raw.run).not.toHaveBeenCalled();
+        });
+
+        it('should pass target along to the emulator', function() {
+            options.target = "sometarget";
+            phonegap.local.install(options);
+            expect(cordova.raw.emulate).toHaveBeenCalledWith(
+                {platforms: options.platforms, options: "--target=sometarget"},
                 jasmine.any(Function)
             );
             expect(cordova.raw.run).not.toHaveBeenCalled();


### PR DESCRIPTION
Related to the pull request in apache/cordova-ios#107

cordova-ios passes --target to ios-sim as --devicetypeid so that you can emulate on difference devices from the CLI.  This change makes it possible to do something like:

phonegap install ios --target "iPhone-5" --emulator
phonegap install ios --target "iPhone-6" --emulator
phonegap install ios --target "iPhone-6-Plus" --emulator

which as far as I can tell is not currently possible in phonegap version 3.5.0-0.21.17
