### PR TITLE
Update cordova 4.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "phonegap",
     "description": "PhoneGap command-line interface and node.js library.",
-    "version": "4.0.0-0.22.7",
+    "version": "4.1.2-0.22.7",
     "homepage": "http://github.com/phonegap/phonegap-cli",
     "repository": {
         "type": "git",


### PR DESCRIPTION
Hey all,

The PhoneGap Developer App has been updated to use Cordova 4.0.0 and is now pending a release in all three app stores.

The PhoneGap Documentation has been updated to 4.0.0 as well. Cordova has not yet officially announced 4.1.0, even though the CLI has landed. Once they update the docs, we can update the PhoneGap Docs as well.

This pull request updates the PhoneGap CLI to 4.1.0. It was a simple one-line change in the package.json. All tests pass. I've also manually tested it by building Android and iOS, running a few Cordova-specific commands, and such.

For historical sake, I also added a prior commit that bumps the PhoneGap CLI to 4.0.0. I use `cordova@4.0.0` instead of `cordova@4.0.1` because the `4.0.1` release references an unavailable `cordova-lib` #fail.

Once you guys give the thumbs up, I'll publish `phonegap@4.0.0` and then `phonegap@4.1.0`, update the PhoneGap documentation, release the PhoneGap Developer app to the public, and publish our blog post explaining it all.

Thanks for the review! /cc @timkim @lorinbeer @hollyschinsky 
