### PR TITLE
[doc] Removing documentation for deprecated commands.

### DIFF
--- a/doc/cli/help.txt
+++ b/doc/cli/help.txt
@@ -9,7 +9,6 @@ Commands:
   help [command]       output usage information
   create <path>        create a phonegap project
   build <platforms>    build the project for a specific platform
-  install <platforms>  install the project on for a specific platform
   run <platforms>      build and install the project for a specific platform
   platform [command]   update a platform version
   plugin [command]     add, remove, and list plugins
@@ -20,7 +19,6 @@ Commands:
 
 Additional Commands:
 
-  local [command]      development on local system
   remote [command]     development in cloud with phonegap/build
   prepare <platforms>  copies www/ into platform project before compiling
   compile <platforms>  compiles platform project without preparing it


### PR DESCRIPTION
As per http://phonegap.com/blog/2014/11/13/phonegap-cli-3-6-3/, these commands are deprecated. Rather than have users discover that these commands are deprecated via the ```phonegap help``` menu, I think it would be clearer to not include them at all, particularly since the current PhoneGap version is 4.2.0.

Thanks!