### PR TITLE
Uses local path as reference

### DIFF
--- a/lib/cordova/index.js
+++ b/lib/cordova/index.js
@@ -4,12 +4,12 @@
 
 var fs = require('fs'),
     path = require('path'),
-    cordovaLibPath = path.join('..', '..', 'node_modules', 'cordova', 'node_modules', 'cordova-lib');
+    cordovaLibPath = path.join(__dirname, '..', '..', 'node_modules', 'cordova', 'node_modules', 'cordova-lib');
 
 // npm 3.x flattens the node_modules/ and moves 'cordova-lib'
 // More info at phonegap/phonegap#515
 if (!fs.existsSync(cordovaLibPath)) {
-    cordovaLibPath = path.join('..', '..', 'node_modules', 'cordova-lib');
+    cordovaLibPath = path.join(__dirname, '..', '..', 'node_modules', 'cordova-lib');
 }
 
 /**


### PR DESCRIPTION
Without __dirname, the lib finds the path based on the actual path.