### PR TITLE
Multiple return formats for `remote run`

### DIFF
--- a/doc/cli/help.remote.run.txt
+++ b/doc/cli/help.remote.run.txt
@@ -12,7 +12,8 @@ Options:
   --host               server host (default: 'build.phonegap.com')
   --port               server port (default: '443')
   --path               server path prefix (default: '/api/v1')
-  --proxy              proxy server to route requests
+  --proxy              proxy server to route requestsformat the response in json or qr (default: 'qr')
+  --format             format the response in json or qr (default: 'qr')
 
 Examples:
 

--- a/doc/cli/help.remote.run.txt
+++ b/doc/cli/help.remote.run.txt
@@ -12,7 +12,7 @@ Options:
   --host               server host (default: 'build.phonegap.com')
   --port               server port (default: '443')
   --path               server path prefix (default: '/api/v1')
-  --proxy              proxy server to route requestsformat the response in json or qr (default: 'qr')
+  --proxy              proxy server to route requests
   --format             format the response in json or qr (default: 'qr')
 
 Examples:

--- a/lib/cli/remote.run.js
+++ b/lib/cli/remote.run.js
@@ -32,7 +32,8 @@ module.exports = function(argv, callback) {
         host: argv.host,
         port: argv.port,
         path: argv.path,
-        proxy: argv.proxy
+        proxy: argv.proxy,
+        format: argv.format
     };
 
     // run the project

--- a/lib/phonegap/remote.run.js
+++ b/lib/phonegap/remote.run.js
@@ -40,7 +40,7 @@ util.inherits(RemoteRunCommand, Command);
  *   - [`options.port`] {String} is the port, e.g. '80' or '443'.
  *   - [`options.path`] {String} is the api path, e.g. '/api/v1'
  *   - [`options.proxy`] {String} is proxy for requests through, e.g. 'http://myproxy.com'
- *   - [`options.format`] {String} is format for response, e.g. qr or json defaults to qr
+ *   - [`options.format`] {String} is format for response, e.g. qr or json, defaults to qr
  *   - [`callback`] {Function} is triggered after completion.
  *     - `e` {Error} is null unless there is an error.
  *
@@ -104,6 +104,7 @@ RemoteRunCommand.prototype.execute = function(options, callback) {
             
             if (options.format && options.format === 'json') {
                 self.phonegap.emit('raw', JSON.stringify({ location: url }));
+                callback(null, data);
             }
         });
     });

--- a/lib/phonegap/remote.run.js
+++ b/lib/phonegap/remote.run.js
@@ -40,6 +40,7 @@ util.inherits(RemoteRunCommand, Command);
  *   - [`options.port`] {String} is the port, e.g. '80' or '443'.
  *   - [`options.path`] {String} is the api path, e.g. '/api/v1'
  *   - [`options.proxy`] {String} is proxy for requests through, e.g. 'http://myproxy.com'
+ *   - [`options.format`] {String} is format for response, e.g. qr or json defaults to qr
  *   - [`callback`] {Function} is triggered after completion.
  *     - `e` {Error} is null unless there is an error.
  *
@@ -90,14 +91,20 @@ RemoteRunCommand.prototype.execute = function(options, callback) {
             var url = 'https://build.phonegap.com' +
                       data.download[platform.remote] +
                       '?auth_token=' + configData.phonegap.token;
-
-            // generate qrcode
-            self.phonegap.emit('log', 'generating the QRCode...');
-            qrcode.generate(url, function(qrcode) {
-                self.phonegap.emit('raw', qrcode);
-                self.phonegap.emit('log', 'install the app by scanning the QRCode');
-                callback(null, data);
-            });
+                      
+            if (!options.format || options.format === 'qr') {
+                // generate qrcode
+                self.phonegap.emit('log', 'generating the QRCode...');
+                qrcode.generate(url, function(qrcode) {
+                    self.phonegap.emit('raw', qrcode);
+                    self.phonegap.emit('log', 'install the app by scanning the QRCode');
+                    callback(null, data);
+                });
+            }
+            
+            if (options.format && options.format === 'json') {
+                self.phonegap.emit('raw', JSON.stringify({ location: url }));
+            }
         });
     });
 };


### PR DESCRIPTION
Allow json to be a return format, next to the already existing qr code. The qr code remains the default.