### PR TITLE
Also output the url with phonegap remote run

### DIFF
--- a/lib/phonegap/remote.run.js
+++ b/lib/phonegap/remote.run.js
@@ -90,6 +90,9 @@ RemoteRunCommand.prototype.execute = function(options, callback) {
             var url = 'https://build.phonegap.com' +
                       data.download[platform.remote] +
                       '?auth_token=' + configData.phonegap.token;
+            
+            // output url
+            self.phonegap.emit('log','url: ' + url);
 
             // generate qrcode
             self.phonegap.emit('log', 'generating the QRCode...');


### PR DESCRIPTION
This was already done for `phonegap remote install`, see #628.