### PR TITLE
[npm] Add webvr to template list.

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,6 +107,10 @@
       "description": "An example app using Framework7 and the Spotify API.",
       "npm": "phonegap-app-star-track"
     },
+    "webvr": {
+      "description": "A WebVR and Google Cardboard demo ported from borismus/webvr-boilerplate.",
+      "npm": "phonegap-template-webvr"
+    },
     "wikitude-augmented-reality": {
       "description": "Augmented Reality demo app powered by the Wikitude plugin",
       "npm": "phonegap-app-augmented-reality"


### PR DESCRIPTION
@shazron ported a great WebVR demo to a PhoneGap Template. This pull request adds the template to our list and gives it the alias `webvr`:

![image](https://cloud.githubusercontent.com/assets/21328/20506051/16155162-b006-11e6-8349-3a0d5ad1f217.png)