### PR TITLE
--save functionality for 'phonegap plugin add'

### DIFF
--- a/lib/cli/cordova.js
+++ b/lib/cli/cordova.js
@@ -36,6 +36,17 @@ module.exports = function(argv, callback) {
 
     // stop cordova-cli from tracking us!
     cordovaCommand.push("--no-telemetry");
+    
+    // append --save by default to phonegap plugin add 
+    var pluginCommands = ["add", "remove", "rm"];
+    var pluginAlias = ["plugin","plugins"];
+    if(cordovaCommand[0] == "cordova" && 
+       pluginAlias.indexOf(cordovaCommand[1]) != -1 && 
+       cordovaCommand.indexOf("--save") == -1 && cordovaCommand.indexOf("--no-save") == -1 &&
+       pluginCommands.indexOf(cordovaCommand[2]) != -1)
+    {
+        cordovaCommand.push("--save");
+    }
 
     // create a string representing the cordova command
     cordovaCommand = cordovaCommand.join(' ');

--- a/lib/cli/cordova.js
+++ b/lib/cli/cordova.js
@@ -1,7 +1,6 @@
 /*!
  * Module dependencies.
  */
-
 var path = require('path'),
     phonegap = require('../main');
 
@@ -36,17 +35,6 @@ module.exports = function(argv, callback) {
 
     // stop cordova-cli from tracking us!
     cordovaCommand.push("--no-telemetry");
-    
-    // append --save by default to phonegap plugin add 
-    var pluginCommands = ["add", "remove", "rm"];
-    var pluginAlias = ["plugin","plugins"];
-    if(cordovaCommand[0] == "cordova" && 
-       pluginAlias.indexOf(cordovaCommand[1]) != -1 && 
-       cordovaCommand.indexOf("--save") == -1 && cordovaCommand.indexOf("--no-save") == -1 &&
-       pluginCommands.indexOf(cordovaCommand[2]) != -1)
-    {
-        cordovaCommand.push("--save");
-    }
 
     // create a string representing the cordova command
     cordovaCommand = cordovaCommand.join(' ');

--- a/lib/phonegap/cordova.js
+++ b/lib/phonegap/cordova.js
@@ -45,11 +45,19 @@ util.inherits(CordovaCommand, Command);
 
 CordovaCommand.prototype.run = function(options, callback) {
     var self = this;
-
     // require options
     if (!options) throw new Error('requires option parameter');
     if (!options.cmd) throw new Error('requires option.cmd parameter');
+    var cordovaCmd = options.cmd.split(" ");
 
+    // append --save by default to phonegap plugin add/remove/rm
+    var pluginCommands = ["add", "remove", "rm"];
+    var pluginAlias = ["plugin", "plugins"];
+    if (pluginAlias.indexOf(cordovaCmd[1]) != -1 &&
+        cordovaCmd.indexOf("--save") == -1 && cordovaCmd.indexOf("--no-save") == -1 &&
+        pluginCommands.indexOf(cordovaCmd[2]) != -1) {
+        options.cmd = options.cmd.concat(" --save");
+    }
     // default options.verbose
     if (isCustomCommand(options)) {
         // these commands can be silenced or verbose

--- a/spec/phonegap/cordova.spec.js
+++ b/spec/phonegap/cordova.spec.js
@@ -169,6 +169,32 @@ describe('phonegap.cordova(options, [callback])', function() {
         });
     });
 
+    describe('adding/removing plugin', function() {
+        it('should save/remove the plugin in config.xml without --save flag', function() {
+            var options1 = {};
+            // test for phonegap plugin add
+            options1.cmd = options.cmd = 'cordova plugin add cordova-plugin-camera';
+            phonegap.cordova(options);
+            //options.cmd now has --save appended.
+            expect(shell.exec).toHaveBeenCalled();
+            expect(options.cmd).toBe(options1.cmd + " --save");
+            expect(shell.exec.mostRecentCall.args[0]).toMatch(options1.cmd + " --save");
+            // test for phonegap plugin rm
+            options1.cmd = options.cmd = 'cordova plugin rm cordova-plugin-camera';
+            phonegap.cordova(options);
+            expect(shell.exec).toHaveBeenCalled();
+            expect(options.cmd).toBe(options1.cmd + " --save");
+            expect(shell.exec.mostRecentCall.args[0]).toMatch(options1.cmd + " --save");
+
+            // test for phonegap plugin remove
+            options1.cmd = options.cmd = 'cordova plugin remove cordova-plugin-camera';
+            phonegap.cordova(options);
+            expect(shell.exec).toHaveBeenCalled();
+            expect(options.cmd).toBe(options1.cmd + " --save");
+            expect(shell.exec.mostRecentCall.args[0]).toMatch(options1.cmd + " --save");
+        });
+    });
+
     describe('add platforms', function() {
         describe('when the command is of the type:', function() {
             beforeEach(function() {


### PR DESCRIPTION
This PR adds a --save functionality for 'phonegap plugin add' by default and updates the config.xml. The addition of --save is implemented only when a --save or --un-save have not been specified in the command. This functionality is also applicable for removing a plugin.