### PR TITLE
Track session ID for analytics

### DIFF
--- a/lib/cli/analytics.js
+++ b/lib/cli/analytics.js
@@ -16,6 +16,7 @@ phonegap analytics reset|on|off
 */
 
 var Insight = require('insight');
+var Configstore = require('configstore');
 var fs = require('fs');
 var path = require('path');
 var request = require('request');
@@ -62,24 +63,6 @@ function getEnvironment(package_json) {
     }
 }
 
-/*
-    Helper function to help build up GELF formatted json
-    TODO: how does GA session vs. user id work?
-    below seems to track user w/ session
-*/
-
-function basicGELF() {
-    return {
-        "version": "1.1",
-        "host": "cli",
-        "short_message": "",
-        "_userID": insight.clientId,
-        "_appVersion": pkg_json.version,
-        "_nodeVersion": process.version,
-        "_platform": os_name(),
-        "_env": getEnvironment(pkg_json)
-    };
-}
 
 /*
     Helper function to send events to the analytics end point
@@ -136,6 +119,39 @@ module.exports = function analytics(argv, callback) {
     callback();
 };
 
+var EVENT_EXPIRY_TIME = 30 * 60 * 1000; // 30 minutes in milliseconds
+module.exports.EVENT_EXPIRY_TIME = EVENT_EXPIRY_TIME;
+// Use the same underlying filesystem config object that the `Insight` module
+// above uses. This way we hopefully don't litter config objects everywhere.
+var config = new Configstore('insight-phonegap');
+module.exports.config = config;
+/*
+    Helper function to help build up GELF formatted json
+*/
+
+function basicGELF() {
+    var event = {
+        "version": "1.1",
+        "host": "cli",
+        "short_message": "",
+        "_userID": insight.clientId,
+        "_session": true,
+        "_appVersion": pkg_json.version,
+        "_nodeVersion": process.version,
+        "_platform": os_name(),
+        "_env": getEnvironment(pkg_json)
+    };
+    var now = (new Date()).valueOf(); // in ms
+    var lastRun = config.get('lastRun');
+    if (lastRun && (now - lastRun < EVENT_EXPIRY_TIME)) {
+        // If the CLI ran consecutive actions within the expiry time, use the same session id.
+        event["_session"] = lastRun;
+    } else {
+        event["_session"] = now;
+        config.set('lastRun', now);
+    }
+    return event;
+}
 module.exports.hasOptedOut = function hasOptedOut() {
     return insight.optOut === true;
 };
@@ -190,7 +206,8 @@ module.exports.trackEvent = function trackEvent(args, error) {
     var label = exitCode + "";
     var value = cleanedResult.count;
     if (module.exports.hasOptedOut() === false) {
-        if (category) {
+        if (cleanedResult.command) {
+            // If we have a command parsed out, send it off to metrics
             var info = basicGELF();
             info.short_message = sanitizeArgs.getCommand(args);
             info._flags = sanitizeArgs.getSwitches(args);

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "connect-phonegap": "0.24.5",
     "cordova": "6.4.0",
     "insight": "0.8.2",
+    "configstore": "1.4.0",
     "os-name": "2.0.1",
     "minimist": "0.1.0",
     "opener": "1.4.1",

--- a/spec/analytics.spec.js
+++ b/spec/analytics.spec.js
@@ -90,7 +90,7 @@ describe('PhoneGap Analytics', function() {
                 var dump = JSON.parse(post_spy.calls[0].args[0].form);
                 expect(dump._session).not.toEqual(session);
                 expect(set_spy).toHaveBeenCalledWith('lastRun', jasmine.any(Number));
-                expect(set_spy.calls[0].args[1]).toEqual(now);
+                expect(Math.abs(set_spy.calls[0].args[1] - now)).toBeLessThan(5); // give some leeway in case the clock ticks on e.g. Travis
             });
         });
     });


### PR DESCRIPTION
Please review @purplecabbage, @surajpindoria, @timkim.
FYI @hermwong @mwbrooks.

Moving session tracking to a client-side mechanism. For the CLI, we will use the same rough heuristic that Google Analytics uses: consecutive actions within 30 minutes of each other are considered the same session.

Implementation details:
1. The session ID will be sent in analytics events under a `_session` property, as per github.com/phonegap/phonegap-metrics.
2. The session ID will be the timestamp of:
  - right now, if it is a brand new session
  - the last/existing session, if we are still within the event expiry time (30 mins).
3. Persistence of the session ID is stored in the same config object that user ID is stored in, via `Configstore`, which the `Insight` module also uses. Once we eventually fully move over to metrics.phonegap.com and off of GA, we can remove `Insight`, but keep this `Configstore` object to keep using the same underlying config file.