### PR TITLE
Add code coverage reporting via travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,12 @@ notifications:
     on_success: change
     on_failure: always
 node_js:
-- '4.0'
+  - '4.0'
+install:
+  - npm install
+  - npm install -g codecov
+script:
+  - npm test
+  - npm run cover
+after_script:
+  - codecov


### PR DESCRIPTION
Changes the travis job to trigger code coverage checking + reporting it up to codecov.io.

See comments from the codecov bot below on example reporting within PRs. Note that, since code coverage via codecov.io is not merged into master yet, the diff report below is not reported. Presumably if/when we merge this into master, we'd start getting diff reports in PRs.