### PR TITLE
Adding no-unused-vars to eslint

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -15,6 +15,7 @@
             "maxEOF": 1
         }],
         "no-trailing-spaces": "error",
+        "no-unused-vars": ["error",{ "args": "none" }],
         "padded-blocks": [1, "never"],
         "semi": ["error", "always"],
         "space-before-blocks": "error"

--- a/bin/phonegap.js
+++ b/bin/phonegap.js
@@ -7,7 +7,6 @@
 var CLI = require('../lib/cli');
 var cli = new CLI();
 var analytics = cli.analytics;
-var version = require('../package.json').version;
 
 if (analytics.statusUnknown()) {
     // if it is an analytics command, just run it

--- a/lib/cli/analytics.js
+++ b/lib/cli/analytics.js
@@ -39,14 +39,10 @@ var insight = new Insight({
     "pkg": pkg_json
 });
 
-var category = 'phonegap@' + pkg_json.version;
-
 var PromptPreamble = '\nHow you use PhoneGap provides us with important data that we can use to make\n' +
                      'our products better. Please read our privacy policy for more information on the\n' +
                      'data we collect. http://www.adobe.com/privacy.html';
 var PromptMessage = 'Would you like to allow PhoneGap to collect anonymous usage data?';
-var UserAcceptedMessage = '\nThank you for helping to make PhoneGap better.\n';
-var UserDeclinedMessage = '\nYou have opted out of analytics. To change this, run: `phonegap analytics on`\n';
 var AnalyticsOffMessage  = '\nAnalytics is off. \nIf you would like to turn analytics on, simply run `phonegap analytics on`\n';
 var AnalyticsOnMessage  = '\nAnalytics is on! Nice, you are helping us improve PhoneGap tooling.\n' +
                          'If you would like to turn analytics off, simply run `phonegap analytics off`\n';

--- a/lib/cli/cordova.js
+++ b/lib/cli/cordova.js
@@ -1,8 +1,7 @@
 /*!
  * Module dependencies.
  */
-var path = require('path'),
-    phonegap = require('../main');
+var phonegap = require('../main');
 
 /**
  * $ phonegap cordova [[commands] options]

--- a/lib/cli/create.js
+++ b/lib/cli/create.js
@@ -2,8 +2,7 @@
  * Module dependencies.
  */
 
-var phonegap = require('../main'),
-    fs = require('fs');
+var phonegap = require('../main');
 
 /**
  * $ phonegap create <path>

--- a/lib/cli/install.js
+++ b/lib/cli/install.js
@@ -2,8 +2,7 @@
  * Module dependencies.
  */
 
-var phonegap = require('../main'),
-    fs = require('fs');
+var phonegap = require('../main');
 
 /**
  * $ phonegap create <path>

--- a/lib/cli/remote.logout.js
+++ b/lib/cli/remote.logout.js
@@ -2,8 +2,7 @@
  * Module dependencies.
  */
 
-var phonegap = require('../main'),
-    console = require('./util/console');
+var phonegap = require('../main');
 
 /**
  * $ phonegap remote logout

--- a/lib/cli/report-issue.js
+++ b/lib/cli/report-issue.js
@@ -1,5 +1,3 @@
-
-
 var opener = require('opener');
 var os_name = require('os-name');
 var pkgjson = require('../../package.json');
@@ -7,12 +5,6 @@ var pkgjson = require('../../package.json');
 var baseUrl = "https://github.com/phonegap/phonegap-cli/issues/new?";
 var prelude = "body=";
 var coda = "%0aSteps+to+Reproduce%3a%0a%0a1.%0a2";
-
-/*!
- * Module dependencies.
- */
-
-var phonegap = require('../main');
 
 /**
  * $ phonegap report-issue

--- a/lib/cli/util/console.js
+++ b/lib/cli/util/console.js
@@ -2,8 +2,7 @@
  * Module dependencies.
  */
 
-var colors = require('colors'),
-    prompt = require('prompt');
+var prompt = require('prompt');
 
 /**
  * Console Log.

--- a/lib/phonegap/create.js
+++ b/lib/phonegap/create.js
@@ -3,11 +3,7 @@
  */
 
 var Command = require('./util/command'),
-    config = require('../common/config'),
-    cordova = require('../cordova').cordova,
     cordovaLib = require('../cordova').lib,
-    network = require('./util/network'),
-    shell = require('shelljs'),
     path = require('path'),
     util = require('util'),
     fs = require('fs');

--- a/lib/phonegap/push.js
+++ b/lib/phonegap/push.js
@@ -3,12 +3,9 @@
  */
 
 var Command = require('./util/command'),
-    path = require('path'),
     util = require('util'),
     fs = require('fs'),
-    http = require('http'),
-    querystring = require('querystring'),
-    project = require('./util/project');
+    http = require('http');
 
 /**
  * Server Default Settings
@@ -60,8 +57,6 @@ PushCommand.prototype.run = function(options, callback) {
  */
 
 PushCommand.prototype.execute = function(options, callback) {
-    var self = this;
-
     if (options.file) {
         var payload = fs.readFileSync(options.file, 'utf8');
         options.payload = payload;

--- a/lib/phonegap/remote.install.js
+++ b/lib/phonegap/remote.install.js
@@ -5,7 +5,6 @@
 var Command = require('./util/command'),
     project = require('./util/project'),
     platforms = require('./util/platform'),
-    phonegapbuild = require('./util/phonegap-build'),
     qrcode = require('qrcode-terminal'),
     util = require('util');
 

--- a/lib/phonegap/remote.run.js
+++ b/lib/phonegap/remote.run.js
@@ -5,7 +5,6 @@
 var Command = require('./util/command'),
     project = require('./util/project'),
     platforms = require('./util/platform'),
-    phonegapbuild = require('./util/phonegap-build'),
     config = require('../common/config'),
     qrcode = require('qrcode-terminal'),
     util = require('util');

--- a/lib/phonegap/share.js
+++ b/lib/phonegap/share.js
@@ -5,7 +5,6 @@ var dropbox = require('./util/dropbox');
 var proxy = require('./util/connect-proxy');
 var serve = require('./serve');
 var cordova = require('../cordova').cordova;
-var fs = require('fs');
 
 /*
  *

--- a/lib/phonegap/util/dropbox.js
+++ b/lib/phonegap/util/dropbox.js
@@ -1,12 +1,10 @@
 var http = require('http');
 var https = require('https');
-var spawn = require('child_process').spawn;
 var opn = require('opn');
 var util = require('util');
 var fs = require('fs');
 var path = require('path');
 var qs = require('querystring');
-var homedir = process.env['HOME'];
 var projectRootPath = require('../../cordova').util.isCordova();
 var settings = projectRootPath ? path.join(projectRootPath, ".dropboxrc") : null;
 
@@ -30,7 +28,6 @@ state=%s`,
                     app_key, redirect_uri, state);
 
                 var server;
-                var browser;
 
                 function handleRequest(request, response) {
                     if (request.url === "/token" && request.method === "POST") {

--- a/lib/phonegap/util/project.js
+++ b/lib/phonegap/util/project.js
@@ -4,7 +4,6 @@
 
 var fs = require('fs'),
     path = require('path'),
-    cordova = require('../cordova').cordova,
     cdvutil = require('../../cordova').util;
 
 /*!
@@ -130,27 +129,6 @@ checkPlatform = function (plat) {
 module.exports.isHome = function(homePath) {
     return (homePath === HOME);
 };
-
-
-module.exports.clobberProjectConfig = function(configPath,clobbertargets) {
-    var fs = require('fs');
-
-    fs.open(configPath,'r+', function(err,fd) {
-        if (err) {
-            return;
-        }
-        fs.readFile(configPath, function(err, data) {
-            if(err) {
-                return;
-            }
-            for (each in clobbertargets) {
-                data.replace(each, clobbertargets[each]);
-            }
-        });
-    });
-    return configPath;
-};
-
 
 /**
  * Madule Exports

--- a/lib/phonegap/version.js
+++ b/lib/phonegap/version.js
@@ -3,9 +3,7 @@
  */
 
 var Command = require('./util/command'),
-    path = require('path'),
     util = require('util'),
-    fs = require('fs'),
     project = require('./util/project');
 
 /*!

--- a/spec/cli/cordova.spec.js
+++ b/spec/cli/cordova.spec.js
@@ -5,8 +5,7 @@
 var phonegap = require('../../lib/main'),
     CLI = require('../../lib/cli'),
     argv,
-    cli,
-    stdout;
+    cli;
 
 /*!
  * Specification: $ phonegap cordova <command>
@@ -18,7 +17,6 @@ describe('$ phonegap cordova', function() {
         argv = ['node', '/usr/local/bin/phonegap'];
         spyOn(process.stdout, 'write');
         spyOn(process.stderr, 'write');
-        stdout = process.stdout.write;
     });
 
     it('should bypass the PhoneGap CLI chain', function(done) {

--- a/spec/cli/install.spec.js
+++ b/spec/cli/install.spec.js
@@ -2,8 +2,7 @@
  * Module dependencies.
  */
 
-var phonegap = require('../../lib/main'),
-    CLI = require('../../lib/cli'),
+var CLI = require('../../lib/cli'),
     argv,
     cli,
     stdout;

--- a/spec/cli/template.spec.js
+++ b/spec/cli/template.spec.js
@@ -2,8 +2,7 @@
  * Module dependencies.
  */
 
-var phonegap = require('../../lib/main'),
-    CLI = require('../../lib/cli'),
+var CLI = require('../../lib/cli'),
     argv,
     cli,
     stdout;

--- a/spec/cli/unknown.spec.js
+++ b/spec/cli/unknown.spec.js
@@ -1,27 +1,16 @@
-/*
- * Module dependencies.
- */
-
-var CLI = require('../../lib/cli'),
-    argv,
-    cli;
-
+var unknown = require('../../lib/cli/unknown');
+var cnsl = require('../../lib/cli/util/console');
 /*
  * Specification: $ phonegap unknown
  */
 
 describe('phonegap unknown', function() {
-    beforeEach(function() {
-        cli = new CLI();
-        argv = ['node', '/usr/local/bin/phonegap'];
-        spyOn(process.stdout, 'write');
-        spyOn(process.stderr, 'write');
+    it('should output the unknown command as "noop"', function() {
+        spyOn(cnsl, 'error');
+        unknown({
+            _:['node', 'phonegap.js', 'noop']
+        }, function() {});
+        expect(cnsl.error.mostRecentCall.args[0]).toMatch('noop');
+        expect(cnsl.error.mostRecentCall.args[0]).toMatch(/is not a \w+ command/);
     });
-
-    //describe('$ phonegap noop', function() {
-    //    it('should output the unknown command as "noop"', function() {
-    //        cli.argv(argv.concat(['noop']));
-    //        expect(process.stdout.write.mostRecentCall.args[0]).toMatch('noop');
-    //    });
-    //});
 });

--- a/spec/cli/util/update-check.spec.js
+++ b/spec/cli/util/update-check.spec.js
@@ -2,24 +2,39 @@
  * Module dependencies.
  */
 
-var CLI = require('../../../lib/cli'),
-    updateCheck = require('../../../lib/cli/util/update-check'),
-    cli;
+var updateCheck = require('../../../lib/cli/util/update-check'),
+    orig_env;
 
 /*
  * Specification: update checker
  */
 
+function trigger_cli() {
+    require('../../../lib/cli');
+}
+
 describe('update checker', function() {
     beforeEach(function() {
+        // save process.env so that we can restore in afterEach()
+        orig_env = process.env;
+        // delete the cli module from require cache
+        // so we can exercise its update logic in each test case
+        // this only happens the first time the module gets required, thus why this exists.
+        delete require.cache[require.resolve('../../../lib/cli')];
         spyOn(updateCheck, 'start');
     });
+    afterEach(function() {
+        process.env = orig_env;
+    });
 
-    it('should check for an update', function(done) {
-        cli = new CLI(function() {
-            expect(updateCheck.start).toHaveBeenCalled();
-        });
-
-        done();
+    it('should check for an update when not running as electron', function() {
+        delete process.env.ELECTRON_RUN_AS_NODE;
+        trigger_cli();
+        expect(updateCheck.start).toHaveBeenCalled();
+    });
+    it('should NOT check for an update when running as electron', function() {
+        process.env.ELECTRON_RUN_AS_NODE = true;
+        trigger_cli();
+        expect(updateCheck.start).not.toHaveBeenCalled();
     });
 });

--- a/spec/phonegap/remote.build.spec.js
+++ b/spec/phonegap/remote.build.spec.js
@@ -5,11 +5,9 @@
 var phonegapbuild = require('../../lib/phonegap/util/phonegap-build'),
     PhoneGap = require('../../lib/phonegap'),
     project = require('../../lib/phonegap/util/project'),
-    events = require('events'),
     phonegap,
     appData,
-    options,
-    stdout;
+    options;
 
 /*
  * Specification: phonegap.remote.build(options, [callback])

--- a/spec/phonegap/remote.install.spec.js
+++ b/spec/phonegap/remote.install.spec.js
@@ -2,8 +2,7 @@
  * Module dependencies.
  */
 
-var phonegapbuild = require('../../lib/phonegap/util/phonegap-build'),
-    PhoneGap = require('../../lib/phonegap'),
+var PhoneGap = require('../../lib/phonegap'),
     project = require('../../lib/phonegap/util/project'),
     qrcode = require('qrcode-terminal'),
     phonegap,

--- a/spec/phonegap/serve.spec.js
+++ b/spec/phonegap/serve.spec.js
@@ -1,10 +1,8 @@
 
 var serveModule = require("../../lib/phonegap/serve"),
-    http = require("http"),
     server = require("connect-phonegap"),
     cordova = require('../../lib/cordova').cordova,
     project = require("../../lib/phonegap/util/project"),
-    preparePromise = null,
     serve = null;
 
 
@@ -117,24 +115,22 @@ describe("PhoneGap serve", function () {
         });
 
         describe("if cordova prepare throws", function () {
-            var invalidOptions,
-                defaultOptions;
+            var defaultOptions;
 
             beforeEach(function () {
-                invalidOptions = {
-                    port: undefined,
-                    autoreload:"batman",
-                    localtunnel:"wonderwoman"
-                };
                 defaultOptions = {
                     port: 3000,
                     autoreload: true,
                     localtunnel: false
                 };
 
-                spyOn(cordova, 'prepare').andCallFake(function () {
+                cordova.prepare.andCallFake(function () {
                     throw new Error('IWETTUM!');
                 });
+            });
+            it('should still serve', function() {
+                serve(defaultOptions);
+                expect(server.listen).toHaveBeenCalledWith(defaultOptions);
             });
         });
 

--- a/spec/phonegap/util/project.spec.js
+++ b/spec/phonegap/util/project.spec.js
@@ -7,7 +7,6 @@ var project = require('../../../lib/phonegap/util/project'),
     events = require('events'),
     chdir = require('chdir'),
     path = require('path'),
-    fs = require('fs'),
     currentPath,
     projectPath,
     delegate;
@@ -131,8 +130,6 @@ describe('project', function() {
 
 
     describe('readPackage', function () {
-        var relativePath;
-
         beforeEach(function() {
             packagepath = path.join(__dirname, '..', '..', '..', 'package.json');
             spyOn(JSON,'parse').andReturn({});
@@ -144,28 +141,6 @@ describe('project', function() {
 
         it('should return the package.json contents', function() {
             expect(project.readPackage()).toEqual({});
-        });
-    });
-
-    describe('clobbersConfig', function() {
-        var fixtureUri = '/User/dev/correct/uri/to/config',
-            fixtureContent = 'aabbcc';
-
-        beforeEach(function() {
-            createSpyObj('fs', ['open','readFile']);
-            spyOn(fs,'readFile').andReturn(null,'');
-        });
-
-        it('should be defined clue', function() {
-            expect(project.clobberProjectConfig).toBeDefined();
-        });
-        it('should return null if path is invalid', function () {
-            var res = project.clobberProjectConfig('blarg',{});
-        });
-        it('should return the path of the config file when successful', function () {
-            var res = project.clobberProjectConfig(fixtureUri, {'aa':'bb','cc':'bb'});
-
-            expect(res).toEqual(fixtureUri);
         });
     });
 });

--- a/spec/shell.spec.js
+++ b/spec/shell.spec.js
@@ -1,5 +1,4 @@
 var cli = require('../lib/cli');
-var analytics = require('../lib/cli/analytics');
 
 function trigger_phonegap_cli() {
     require('../bin/phonegap');
@@ -16,40 +15,42 @@ describe('$ phonegap [options] commands', function() {
         // dont log analytics during tests - fake the cli out into thinking we opted out
         spyOn(cli.prototype.analytics, 'hasOptedOut').andReturn(true);
         orig_args = process.argv;
+        spyOn(console, 'log');
     });
     afterEach(function() {
         process.argv = orig_args;
     });
 
     it('should support no arguments and post help', function() {
-        spyOn(console, 'log');
+        process.argv = ['node', 'phonegap.js'];
         trigger_phonegap_cli();
         expect(console.log.mostRecentCall.args[0]).toMatch('Usage:');
     });
 
     it('should support commands', function() {
         process.argv = ['node', 'phonegap.js', 'version'];
-        spyOn(console, 'log');
         trigger_phonegap_cli();
         expect(console.log.mostRecentCall.args[0]).toMatch(/^\w+\.\w+\.\w+/);
     });
 
     it('should support options', function() {
         process.argv = ['node', 'phonegap.js', '--version'];
-        spyOn(console, 'log');
         trigger_phonegap_cli();
         expect(console.log.mostRecentCall.args[0]).toMatch(/^\w+\.\w+\.\w+/);
     });
 
     it('should have exit code 0 on successful commands', function() {
         process.argv = ['node', 'phonegap.js', '--version'];
-        spyOn(console, 'log');
         trigger_phonegap_cli();
         expect(process.exitCode).toEqual(0);
     });
 
     describe('on an error', function() {
         it('should have non-zero exit code', function() {
+            // in updateCheck.spec, we clear require cache to exercise lib/cli properly.
+            // here we re-require it just so we have a loaded cache and are using the
+            // actual lib/cli module when spying on the cli prototype below.
+            cli = require('../lib/cli');
             process.argv = ['node', 'phonegap.js', 'cordova', 'noop'];
             spyOn(cli.prototype, 'argv').andCallFake(function(args, cb) {
                 // have argv just blast back an error object to the callback to trigger error flow


### PR DESCRIPTION
Also:
 - Removing unused method from util/project, and associated tests.
 - Removing tons of unused variables.
 - Adds a few tests: `serve` when `prepare` fails, unknown module specs too.
 - Made a few of the specs a bit more independent / ensured we clean up after the tests appropriately.

Fixes #702: removing unused variables