### PR TITLE
#711: Analytics to treat the -v or --version switches as a top-level command

### DIFF
--- a/lib/cli/util/sanitize-args.js
+++ b/lib/cli/util/sanitize-args.js
@@ -51,9 +51,12 @@ function indexOfAny(arr1,arr2) {
 }
 
 // returns an array of args that are NOT switches
-function filterSwitches(args) {
+// optional parameter that controls filtering out `-v` or `--version`, as that is treated
+// as a top-level command in pg-cli, so useful to treat it uniquely. default to filter out.
+function filterSwitches(args, filterVersion) {
+    filterVersion = (typeof filterVersion != 'undefined' ? filterVersion : true);
     return args.filter(function(arg) {
-        return arg && !(arg.indexOf("-") === 0);
+        return arg && (filterVersion ? !(arg.indexOf("-") === 0) : (arg == "-v" || arg == "--version" || !(arg.indexOf("-") === 0)));
     });
 }
 
@@ -133,6 +136,10 @@ function filterParameters(args) {
 // Returns a string representing the command the user ran.
 // May return a compound command in the case of "cordova" or "local" commands
 function getCommand(args) {
+    // for the filterVersion parameter below, for the purposes of retrieving
+    // the top-level command invoked, we treat the -v / --version flag as a
+    // top-level command, so, lets not filter out version switches in this case.
+    args = filterSwitches(args, false/*filterVersion*/);
     var cmd = args[0] || "help"; // if no command is passed, assume it is help
     if (cmd.toLowerCase() == "cordova" || cmd.toLowerCase() == "local") {
         cmd += ":" + args[1];

--- a/spec/cli/util/sanitize-args.spec.js
+++ b/spec/cli/util/sanitize-args.spec.js
@@ -372,6 +372,15 @@ describe('sanitize-args', function() {
         it('should return "help" by default if no arguments are given', function() {
             expect(sanitizeArgs.getCommand([])).toEqual('help');
         });
+        it('should return the main command when no switches are provided', function() {
+            expect(sanitizeArgs.getCommand(['serve'])).toEqual('serve');
+        });
+        it('should return the main command when switches are provided at the end', function() {
+            expect(sanitizeArgs.getCommand(['serve', '-d'])).toEqual('serve');
+        });
+        it('should return the main command when switches are provided at the start', function() {
+            expect(sanitizeArgs.getCommand(['-d', 'serve'])).toEqual('serve');
+        });
     });
     describe('filterParameters', function() {
         it('should be able to handle zero arguments', function() {


### PR DESCRIPTION
Fixes #711.