### PR TITLE
Track uncaught exceptions as "crash" events in analytics

### DIFF
--- a/bin/phonegap.js
+++ b/bin/phonegap.js
@@ -8,6 +8,20 @@ var CLI = require('../lib/cli');
 var cli = new CLI();
 var analytics = cli.analytics;
 
+process.on('uncaughtException', function(err) {
+    console.error('There was an unhandled exception within phonegap-cli! If you would like to help the PhoneGap project, please file the following details over at https://github.com/phonegap/phonegap-cli/issues');
+    console.error(err.stack);
+    var args = Array.prototype.slice.call(process.argv).slice(2);
+    // Track event using standard analytics lib, but provide third argument
+    // that are 'overrides' so that we can force the event name to be a "crash"
+    // and force tracking of original parameters.
+    analytics.trackEvent(args, err, {
+        short_message: "crash",
+        _params: args
+    });
+    process.exit(1);
+});
+
 if (analytics.statusUnknown()) {
     // if it is an analytics command, just run it
     if (process.argv.length > 2 && process.argv[2] === 'analytics') {

--- a/lib/cli/analytics.js
+++ b/lib/cli/analytics.js
@@ -22,6 +22,7 @@ var path = require('path');
 var request = require('request');
 var sanitizeArgs = require('./util/sanitize-args');
 var os_name = require('os-name');
+var util = require('util');
 
 // Google Analytics tracking code
 var trackingCode = 'UA-94271-37'; // this is the default production tracking code
@@ -201,7 +202,16 @@ module.exports.statusUnknown = function statusUnknown() {
     return insight.optOut === undefined;
 };
 
-module.exports.trackEvent = function trackEvent(args, error) {
+/**
+ * Given a set of arguments passed to the CLI, optional error object, and
+ * optional event overrides, combine all parameters into an event object
+ * suitable for use in tracking for analytics.
+ *
+ * @param  {string[]} args [command line arguments passed to the cli]
+ * @param  {Object} error   [optional object representing an error that occurred] (optional)
+ * @param  {Object} overrides   [properties in this object will override whatever exists in the final analytics event object] (optional)
+ */
+module.exports.trackEvent = function trackEvent(args, error, overrides) {
     // if we received an error, then we will exit with an error status
     // if an exit code was attached to the error, then use it
     // otherwise default to 1.
@@ -222,6 +232,10 @@ module.exports.trackEvent = function trackEvent(args, error) {
             if (error) {
                 if (error.stack) info._error_stack = error.stack;
                 if (error.output) info._error_msg = error.output;
+                if (error.message) info._error_msg = error.message;
+            }
+            if (overrides) {
+                info = util._extend(info, overrides);
             }
             sendAnalytics(info);
         }

--- a/spec/analytics.spec.js
+++ b/spec/analytics.spec.js
@@ -66,6 +66,11 @@ describe('PhoneGap Analytics', function() {
             var dump = JSON.parse(post_spy.calls[0].args[0].form);
             expect(dump._params).toContain('list');
         });
+        it('should honour the overrides parameter (third param)', function() {
+            analytics.trackEvent(['serve', '--no-autoreload'], null/*error*/, {short_message:"OVERRULED!"});
+            var dump = JSON.parse(post_spy.calls[0].args[0].form);
+            expect(dump.short_message).toEqual('OVERRULED!');
+        });
         describe('session tracking', function() {
             it('should tag events with a session id', function() {
                 var cmd = ['plugins', 'list'];

--- a/spec/shell.spec.js
+++ b/spec/shell.spec.js
@@ -60,4 +60,31 @@ describe('$ phonegap [options] commands', function() {
             expect(process.exitCode).toEqual(1337);
         });
     });
+    /*
+     * Unfortunately, the below does not work with jasmine-node
+     * I really really tried to implement a test for the uncaught exception handler
+     * to no avail. jasmine-node just exits prematurely.
+     * Perhaps when we move to jasmine2 this can be tested properly.
+    describe('when node throws an uncaught exception', function() {
+        beforeEach(function() {
+            jasmine.CATCH_EXCEPTIONS = false;
+        });
+        afterEach(function() {
+            jasmine.CATCH_EXCEPTIONS = true;
+        });
+        it('should track the event in analytics', function(done) {
+            spyOn(cli.prototype.analytics, 'trackEvent');
+            spyOn(console, 'error');
+            cli = require('../lib/cli');
+            process.argv = ['node', 'phonegap.js', 'die', 'inafire'];
+            spyOn(cli.prototype, 'argv').andCallFake(function(args, cb) {
+                throw 'Poop!';
+            });
+            expect(trigger_phonegap_cli).toThrow();
+            expect(console.error.mostRecentCall.args[0]).toMatch('There was an unhandled exception');
+            expect(cli.prototype.analytics.trackEvent).toHaveBeenCalledWith(['die', 'inafire']);
+            done();
+        });
+    });
+    */
 });


### PR DESCRIPTION
Fixes #714.

Also adds ability for the `analytics.trackEvent` method to be given an `overrides` parameter, for forcing certain analytic event properties to specific values. Added test for that functionality.

Added a commented-out stub of a test for uncaughtException handling - unfortunately that is pretty hard in jasmine-node :/

FYI / please review @purplecabbage, @surajpindoria. Perhaps some of the wording in an uncaught exception / crash scenario could be better, I'm not sure, but comments welcome!