### PR TITLE
added spinner for cordova install, analytics tracks dl time

### DIFF
--- a/lib/phonegap/cordova-dependence.js
+++ b/lib/phonegap/cordova-dependence.js
@@ -4,6 +4,9 @@ var fs = require('fs'),
     Q = require('q'),
     shell = require('shelljs'),
     cordova_common = require('cordova-common');
+var ora = require('ora');
+var analytics = require('../cli/analytics');
+
 /**
  * Given a PhoneGap project, pin Cordova as a dependency. Installation is not verified if dependency already exists.
  *
@@ -69,9 +72,25 @@ module.exports.exec = function(projectDir, extEvents) {
                 var cordovaCommand = 'npm install cordova --save';
                 extEvents.emit('log', 'Adding Cordova dependency with: "' + cordovaCommand + '"');
                 extEvents.emit('log', 'This may take a few minutes ...');
+
+                var spinner = ora('installing cordova').start();
+
+                var startTime = Date.now();
+                analytics.trackEvent([], 0, {
+                    short_message: "npm-install-cordova-start",
+                    _params: []
+                });
+
                 var child = shell.exec(cordovaCommand, {
                     silent: true
                 }, function(code, stdout, stderr) {
+                    spinner.stop();
+                    var dT = Date.now() - startTime;
+                    var dTsec = Math.round(dT / 1000) + "s"; // analytics does not like numbers,
+                    analytics.trackEvent([dTsec], code, {
+                        short_message: "npm-install-cordova-finish",
+                        _params: [dTsec]
+                    });
                     if (code != 0) {
                         e = new Error('Error from npm: ' + stdout.replace('\n', ''));
                         e.exitCode = code;

--- a/lib/phonegap/cordova-dependence.js
+++ b/lib/phonegap/cordova-dependence.js
@@ -86,10 +86,10 @@ module.exports.exec = function(projectDir, extEvents) {
                 }, function(code, stdout, stderr) {
                     spinner.stop();
                     var dT = Date.now() - startTime;
-                    var dTsec = Math.round(dT / 1000) + "s"; // analytics does not like numbers,
-                    analytics.trackEvent([dTsec], code, {
+                    var dTsec = Math.round(dT / 1000);
+                    analytics.trackEvent([], code, {
                         short_message: "npm-install-cordova-finish",
-                        _params: [dTsec]
+                        _duration: dTsec
                     });
                     if (code != 0) {
                         e = new Error('Error from npm: ' + stdout.replace('\n', ''));

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "minimist": "0.1.0",
     "opener": "1.4.1",
     "opn": "^4.0.2",
+    "ora": "^1.2.0",
     "os-name": "2.0.1",
     "phonegap-build": "0.10.0",
     "prompt": "0.2.11",


### PR DESCRIPTION
analytics logs both start and stop, so we can also see if people are exiting and not waiting.
messages are npm-install-cordova-start, and npm-install-cordova-finish and are showing up in kibana now.