### PR TITLE
Update dependency to Cordova 7.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ There are a few steps that should be taken when upgrading to a new version of th
 1. Update the `package.json` version.
 
         {
-          "version": "3.1.0-0.15.0"
+          "version": "3.1.0+cordova.0.15.0"
         }
 
 1. Run the tests.
@@ -241,11 +241,12 @@ There are a few steps that should be taken when upgrading to a new version of th
 
 1. Commit stating the version increment.
 
-        $ git commit -am "Version 3.1.0-0.15.0"
+        $ git add package.json
+        $ git commit -am "Version 3.1.0+cordova.0.15.0"
 
 1. Tag the version commit.
 
-        $ git tag 3.1.0-0.15.0
+        $ git tag 3.1.0+cordova.0.15.0
 
 1. Update the [PhoneGap Hello World App](https://github.com/phonegap/phonegap-app-hello-world) to match the new version.
   - See [Update instructions](https://github.com/phonegap/phonegap-app-hello-world#updating-the-application).
@@ -285,5 +286,3 @@ data we collect.
 [package-template]: https://github.com/phonegap/phonegap-cli/blob/035057713c613cc0488e4b0beb5b72c4c820d54a/package.json#L67-L76
 [bithound-img]: https://www.bithound.io/github/phonegap/phonegap-cli/badges/score.svg
 [bithound-url]: https://www.bithound.io/github/phonegap/phonegap-cli
-
-

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "phonegap",
   "description": "PhoneGap command-line interface and node.js library.",
-  "version": "6.5.2+cordova.6.5.0",
+  "version": "6.5.2+cordova.7.0.1",
   "license": "Apache-2.0",
   "homepage": "http://github.com/phonegap/phonegap-cli",
   "repository": {
@@ -32,7 +32,7 @@
     "archiver": "^1.0.0",
     "colors": "0.6.0-1",
     "connect-phonegap": "0.24.7",
-    "cordova": "6.5.0",
+    "cordova": "7.0.1",
     "insight": "0.8.2",
     "configstore": "1.4.0",
     "os-name": "2.0.1",


### PR DESCRIPTION
I've run the tests included in the package and they all passed. I've also created a new app using this branch and it correctly includes cordova 7.0.1.

Before this gets merged and published to npm we should decide what version of PG this will be.