### PR TITLE
Remove anoying space on 'cordova prepare' command

### DIFF
--- a/lib/phonegap/cordova.js
+++ b/lib/phonegap/cordova.js
@@ -148,7 +148,7 @@ CordovaCommand.prototype.execute = function (options, callback) {
 
     // output the command being excuted
     if (isCustomCommand(options)) {
-        var cleanCommand = options.cmd.replace('--no-telemetry', '');
+        var cleanCommand = options.cmd.replace('--no-telemetry', '').trim();
         self.phonegap.emit('log', 'executing', '\'' + cleanCommand + '\' ...');
     }
 


### PR DESCRIPTION
 remove anoying space on `phonegap prepare` command and other `clearCommand`s

![fix](https://user-images.githubusercontent.com/13422799/36979105-25196bee-208f-11e8-9996-3efd049cf602.png)
